### PR TITLE
Budgets screen

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'mobile/**'
+      - 'shared/**'
       - 'priv/static/openapi.json'
       - '.github/workflows/mobile.yml'
   push:

--- a/lib/spendable_web/live/budgets.ex
+++ b/lib/spendable_web/live/budgets.ex
@@ -1,6 +1,8 @@
 defmodule SpendableWeb.Live.Budgets do
   use SpendableWeb, :live_view
 
+  import SpendableWeb.Utils.BudgetCard
+
   alias Spendable.Banks
   alias Spendable.Budgets
   alias Spendable.Budgets.Schemas.Budget
@@ -122,7 +124,7 @@ defmodule SpendableWeb.Live.Budgets do
               <span class="text-xs uppercase tracking-wide text-gray-400">{card.label}</span>
             </div>
             <div :if={card.percent} class="mt-4 h-1 w-full rounded-full bg-white/10">
-              <div class={["h-1 rounded-full", card.bar_class]} style={"width: #{card.percent}%"} />
+              <div class={["h-1 rounded-full", bar_class(card.bar)]} style={"width: #{card.percent}%"} />
             </div>
             <p class="mt-3 text-xs text-gray-400">{card.footer}</p>
           </li>
@@ -292,50 +294,18 @@ defmodule SpendableWeb.Live.Budgets do
 
   defp build_cards(budgets, spent, current_month_is_selected) do
     Enum.map(budgets, fn budget ->
+      spent_here = spent |> Map.get(budget.id, Decimal.new(0)) |> Decimal.abs()
+
       budget
-      |> build_card(spent |> Map.get(budget.id, Decimal.new(0)) |> Decimal.abs(), current_month_is_selected)
+      |> build_budget_card(spent_here, current_month_is_selected)
       |> Map.merge(%{budget: budget, pill: pill(budget.type), pill_class: pill_class(budget.type)})
     end)
   end
 
-  # A past month is a record of what was spent, so a balance read now says nothing about it.
-  defp build_card(_budget, spent, false = _current_month_is_selected) do
-    %{amount: spent, label: "SPENT", percent: nil, bar_class: nil, footer: nil}
-  end
-
-  defp build_card(%Budget{type: :tracking}, spent, _current_month_is_selected) do
-    %{amount: spent, label: "SPENT", percent: nil, bar_class: nil, footer: "No limit set"}
-  end
-
-  defp build_card(%Budget{type: :envelope, budgeted_amount: nil} = budget, _spent, _current_month_is_selected) do
-    %{amount: budget.balance, label: "LEFT", percent: nil, bar_class: nil, footer: "No limit set"}
-  end
-
-  defp build_card(%Budget{type: :envelope} = budget, spent, _current_month_is_selected) do
-    over_budget? = Decimal.compare(spent, budget.budgeted_amount) == :gt
-
-    %{
-      amount: budget.balance,
-      label: "LEFT",
-      percent: percent(spent, budget.budgeted_amount),
-      bar_class: if(over_budget?, do: "bg-red-500", else: "bg-blue-500"),
-      footer: "#{Utils.format_currency(spent)} of #{Utils.format_currency(budget.budgeted_amount)} spent"
-    }
-  end
-
-  defp build_card(%Budget{type: :goal, budgeted_amount: nil} = budget, _spent, _current_month_is_selected) do
-    %{amount: budget.balance, label: "SAVED", percent: nil, bar_class: nil, footer: "No goal set"}
-  end
-
-  defp build_card(%Budget{type: :goal} = budget, _spent, _current_month_is_selected) do
-    %{
-      amount: Decimal.sub(budget.budgeted_amount, budget.balance),
-      label: "TO GO",
-      percent: percent(budget.balance, budget.budgeted_amount),
-      bar_class: "bg-green-500",
-      footer: "#{Utils.format_currency(budget.balance)} of #{Utils.format_currency(budget.budgeted_amount)} saved"
-    }
-  end
+  # Only reached when there is a percent to draw, and a card has a bar exactly when it has one.
+  defp bar_class("over"), do: "bg-red-500"
+  defp bar_class("under"), do: "bg-blue-500"
+  defp bar_class("goal"), do: "bg-green-500"
 
   defp pill(:tracking), do: "Tracking"
   defp pill(:envelope), do: "Envelope"
@@ -344,19 +314,4 @@ defmodule SpendableWeb.Live.Budgets do
   defp pill_class(:tracking), do: "text-gray-400 bg-gray-400/10 ring-gray-400/20 group-hover:ring-gray-400/50"
   defp pill_class(:envelope), do: "text-blue-400 bg-blue-400/10 ring-blue-400/20 group-hover:ring-blue-400/50"
   defp pill_class(:goal), do: "text-green-400 bg-green-400/10 ring-green-400/20 group-hover:ring-green-400/50"
-
-  defp percent(_part, %Decimal{coef: 0}), do: 0.0
-
-  defp percent(part, whole) do
-    part
-    |> Decimal.div(whole)
-    |> Decimal.mult(100)
-    |> Decimal.to_float()
-    |> max(0.0)
-    |> min(100.0)
-    |> Float.round(1)
-  end
-
-  # Goals save toward a target and tracking budgets reserve nothing, so neither is money
-  # this month was meant to be spent against.
 end

--- a/lib/spendable_web/utils/budget_card.ex
+++ b/lib/spendable_web/utils/budget_card.ex
@@ -1,0 +1,65 @@
+defmodule SpendableWeb.Utils.BudgetCard do
+  @moduledoc """
+  What a budget reads as on the budgets screen: the number to show, what to call it, how far
+  along the bar is, and the line underneath.
+
+  Extracted from the LiveView rather than left private because the iOS client has to reach the
+  same six answers, and `shared/budget_cards.json` drives a table test on both sides. Colours
+  stay with each client - `bar` says which of the three bars this is, not what it looks like.
+  """
+
+  import Spendable.Utils
+
+  alias Spendable.Budgets.Schemas.Budget
+
+  # A past month is a record of what was spent, so a balance read now says nothing about it.
+  def build_budget_card(_budget, spent, false = _current_month_is_selected) do
+    %{amount: spent, label: "SPENT", percent: nil, bar: nil, footer: nil}
+  end
+
+  def build_budget_card(%Budget{type: :tracking}, spent, _current_month_is_selected) do
+    %{amount: spent, label: "SPENT", percent: nil, bar: nil, footer: "No limit set"}
+  end
+
+  def build_budget_card(%Budget{type: :envelope, budgeted_amount: nil} = budget, _spent, _current) do
+    %{amount: budget.balance, label: "LEFT", percent: nil, bar: nil, footer: "No limit set"}
+  end
+
+  def build_budget_card(%Budget{type: :envelope} = budget, spent, _current_month_is_selected) do
+    over_budget? = Decimal.compare(spent, budget.budgeted_amount) == :gt
+
+    %{
+      amount: budget.balance,
+      label: "LEFT",
+      percent: percent(spent, budget.budgeted_amount),
+      bar: if(over_budget?, do: "over", else: "under"),
+      footer: "#{format_currency(spent)} of #{format_currency(budget.budgeted_amount)} spent"
+    }
+  end
+
+  def build_budget_card(%Budget{type: :goal, budgeted_amount: nil} = budget, _spent, _current) do
+    %{amount: budget.balance, label: "SAVED", percent: nil, bar: nil, footer: "No goal set"}
+  end
+
+  def build_budget_card(%Budget{type: :goal} = budget, _spent, _current_month_is_selected) do
+    %{
+      amount: Decimal.sub(budget.budgeted_amount, budget.balance),
+      label: "TO GO",
+      percent: percent(budget.balance, budget.budgeted_amount),
+      bar: "goal",
+      footer: "#{format_currency(budget.balance)} of #{format_currency(budget.budgeted_amount)} saved"
+    }
+  end
+
+  defp percent(_part, %Decimal{coef: 0}), do: 0.0
+
+  defp percent(part, whole) do
+    part
+    |> Decimal.div(whole)
+    |> Decimal.mult(100)
+    |> Decimal.to_float()
+    |> max(0.0)
+    |> min(100.0)
+    |> Float.round(1)
+  end
+end

--- a/lib/spendable_web/utils/budget_card_test.exs
+++ b/lib/spendable_web/utils/budget_card_test.exs
@@ -1,0 +1,44 @@
+defmodule SpendableWeb.Utils.BudgetCardTest do
+  use ExUnit.Case, async: true
+
+  import Spendable.Utils
+  import SpendableWeb.Utils.BudgetCard
+
+  alias Spendable.Budgets.Schemas.Budget
+
+  # The iOS client reaches these same answers in Dart, so the table is what keeps the two honest.
+  # mobile/test/budgets/budget_card_test.dart reads the same file.
+  @fixtures "shared/budget_cards.json" |> File.read!() |> Jason.decode!()
+
+  for fixture <- @fixtures["cards"] do
+    @fixture fixture
+
+    test @fixture["name"] do
+      budgeted_amount = @fixture["budget"]["budgeted_amount"]
+
+      budget = %Budget{
+        type: String.to_existing_atom(@fixture["budget"]["type"]),
+        balance: Decimal.new(@fixture["budget"]["balance"]),
+        budgeted_amount: budgeted_amount && Decimal.new(budgeted_amount)
+      }
+
+      card = build_budget_card(budget, Decimal.new(@fixture["spent"]), @fixture["current_month"])
+
+      assert card.label == @fixture["card"]["label"]
+      assert card.percent == @fixture["card"]["percent"]
+      assert card.bar == @fixture["card"]["bar"]
+      assert card.footer == @fixture["card"]["footer"]
+      assert Decimal.equal?(card.amount, Decimal.new(@fixture["card"]["amount"]))
+    end
+  end
+
+  for fixture <- @fixtures["currency"] do
+    @currency fixture
+
+    test "formats #{inspect(fixture["amount"])} as #{fixture["formatted"]}" do
+      amount = @currency["amount"] && Decimal.new(@currency["amount"])
+
+      assert format_currency(amount) == @currency["formatted"]
+    end
+  end
+end

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'auth/account_screen.dart';
 import 'auth/auth_controller.dart';
 import 'auth/sign_in_screen.dart';
+import 'budgets/budgets_screen.dart';
 import 'theme.dart';
 
 class SpendableApp extends ConsumerWidget {
@@ -20,7 +20,7 @@ class SpendableApp extends ConsumerWidget {
       // Null only while the first Keychain read is in flight. Signing in and out never puts this
       // back into loading, so the screen cannot fall back to the splash mid-flow.
       home: switch (auth.value) {
-        true => const AccountScreen(),
+        true => const BudgetsScreen(),
         false => const SignInScreen(),
         null => const _Splash(),
       },

--- a/mobile/lib/budgets/budget_card.dart
+++ b/mobile/lib/budgets/budget_card.dart
@@ -1,0 +1,64 @@
+import 'package:decimal/decimal.dart';
+import 'package:spendable_api/spendable_api.dart';
+
+import '../money.dart';
+
+/// Which of the three bars a card draws. Colours are the screen's business.
+enum CardBar { under, over, goal }
+
+/// What a budget reads as, mirroring `SpendableWeb.Utils.BudgetCard`. Both are driven by
+/// shared/budget_cards.json, which is the only thing keeping them from drifting apart.
+class BudgetCard {
+  const BudgetCard({required this.amount, required this.label, this.percent, this.bar, this.footer});
+
+  factory BudgetCard.build({required Budget budget, required Decimal spent, required bool currentMonth}) {
+    // A past month is a record of what was spent, so a balance read now says nothing about it.
+    if (!currentMonth) return BudgetCard(amount: spent, label: 'SPENT');
+
+    if (budget.type == BudgetTypeEnum.tracking) {
+      return BudgetCard(amount: spent, label: 'SPENT', footer: 'No limit set');
+    }
+
+    final goal = budget.type == BudgetTypeEnum.goal;
+    final balance = money(budget.balance);
+    final budgeted = budget.budgetedAmount == null ? null : money(budget.budgetedAmount!);
+
+    if (budgeted == null) {
+      return goal
+          ? BudgetCard(amount: balance, label: 'SAVED', footer: 'No goal set')
+          : BudgetCard(amount: balance, label: 'LEFT', footer: 'No limit set');
+    }
+
+    if (goal) {
+      return BudgetCard(
+        amount: budgeted - balance,
+        label: 'TO GO',
+        percent: _percent(balance, budgeted),
+        bar: CardBar.goal,
+        footer: '${formatCurrency(balance)} of ${formatCurrency(budgeted)} saved',
+      );
+    }
+
+    return BudgetCard(
+      amount: balance,
+      label: 'LEFT',
+      percent: _percent(spent, budgeted),
+      bar: spent > budgeted ? CardBar.over : CardBar.under,
+      footer: '${formatCurrency(spent)} of ${formatCurrency(budgeted)} spent',
+    );
+  }
+
+  final Decimal amount;
+  final String label;
+  final double? percent;
+  final CardBar? bar;
+  final String? footer;
+
+  static double _percent(Decimal part, Decimal whole) {
+    if (whole == Decimal.zero) return 0;
+
+    final value = (part / whole).toDecimal(scaleOnInfinitePrecision: 28).toDouble() * 100;
+
+    return double.parse(value.clamp(0, 100).toStringAsFixed(1));
+  }
+}

--- a/mobile/lib/budgets/budget_form.dart
+++ b/mobile/lib/budgets/budget_form.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spendable_api/spendable_api.dart';
+
+import '../api/api_error.dart';
+import 'budgets_controller.dart';
+
+const _types = {
+  BudgetRequestTypeEnum.envelope: 'Envelope',
+  BudgetRequestTypeEnum.goal: 'Goal',
+  BudgetRequestTypeEnum.tracking: 'Track spending only',
+};
+
+/// Editing one budget. `balance` is what the user wants allocated; the server diffs it into an
+/// adjustment and answers with the recalculated figure, so nothing here is worked out locally.
+class BudgetForm extends ConsumerStatefulWidget {
+  const BudgetForm({super.key, this.budget});
+
+  final Budget? budget;
+
+  @override
+  ConsumerState<BudgetForm> createState() => _BudgetFormState();
+}
+
+class _BudgetFormState extends ConsumerState<BudgetForm> {
+  late final _name = TextEditingController(text: widget.budget?.name ?? '');
+  late final _budgetedAmount = TextEditingController(text: widget.budget?.budgetedAmount ?? '');
+  late final _balance = TextEditingController(text: widget.budget?.balance ?? '');
+
+  late var _type = switch (widget.budget?.type) {
+    BudgetTypeEnum.goal => BudgetRequestTypeEnum.goal,
+    BudgetTypeEnum.tracking => BudgetRequestTypeEnum.tracking,
+    _ => BudgetRequestTypeEnum.envelope,
+  };
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _budgetedAmount.dispose();
+    _balance.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(budgetsControllerProvider);
+    final errors = state.error is ApiError
+        ? (state.error! as ApiError).fieldErrors
+        : const <String, String>{};
+    final tracking = _type == BudgetRequestTypeEnum.tracking;
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 24,
+        right: 24,
+        top: 24,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            widget.budget == null ? 'New budget' : 'Edit budget',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            key: const Key('budget-name'),
+            controller: _name,
+            decoration: InputDecoration(labelText: 'Name', errorText: errors['/name']),
+          ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField(
+            key: const Key('budget-type'),
+            initialValue: _type,
+            decoration: const InputDecoration(labelText: 'Budget type'),
+            items: [
+              for (final entry in _types.entries)
+                DropdownMenuItem(value: entry.key, child: Text(entry.value)),
+            ],
+            onChanged: (value) => setState(() => _type = value ?? _type),
+          ),
+          if (!tracking) ...[
+            const SizedBox(height: 16),
+            TextField(
+              key: const Key('budget-amount'),
+              controller: _budgetedAmount,
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              decoration: InputDecoration(
+                labelText: _type == BudgetRequestTypeEnum.goal ? 'Goal amount' : 'Budgeted amount',
+                errorText: errors['/budgeted_amount'],
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              key: const Key('budget-balance'),
+              controller: _balance,
+              keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: true),
+              decoration: InputDecoration(labelText: 'Allocated', errorText: errors['/balance']),
+            ),
+          ],
+          const SizedBox(height: 24),
+          FilledButton(
+            key: const Key('budget-save'),
+            onPressed: state.isLoading ? null : _save,
+            child: const Text('Save'),
+          ),
+          if (widget.budget case final budget?) ...[
+            const SizedBox(height: 8),
+            TextButton(
+              key: const Key('budget-archive'),
+              onPressed: state.isLoading ? null : () => _archive(budget.id),
+              style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
+              child: const Text('Archive budget'),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Future<void> _save() async {
+    final tracking = _type == BudgetRequestTypeEnum.tracking;
+
+    final request = BudgetRequest(
+      (builder) => builder
+        ..name = _name.text
+        ..type = _type
+        ..budgetedAmount = tracking ? null : _blankToNull(_budgetedAmount.text)
+        ..balance = tracking ? null : _blankToNull(_balance.text),
+    );
+
+    await _close(ref.read(budgetsControllerProvider.notifier).save(id: widget.budget?.id, request: request));
+  }
+
+  Future<void> _archive(String id) => _close(ref.read(budgetsControllerProvider.notifier).archive(id));
+
+  /// A failure keeps the sheet open so the field errors have somewhere to land.
+  Future<void> _close(Future<bool> write) async {
+    final saved = await write;
+
+    if (saved && mounted) Navigator.of(context).pop();
+  }
+
+  String? _blankToNull(String value) => value.trim().isEmpty ? null : value.trim();
+}

--- a/mobile/lib/budgets/budgets_controller.dart
+++ b/mobile/lib/budgets/budgets_controller.dart
@@ -1,0 +1,42 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:spendable_api/spendable_api.dart';
+
+import '../api/api_client.dart';
+import '../api/api_error.dart';
+import 'budgets_providers.dart';
+
+part 'budgets_controller.g.dart';
+
+/// Writing budgets. Every write re-reads the summary rather than patching the list: changing one
+/// budget's allocation moves what is left on Spendable, so the row that came back is not the only
+/// one that changed.
+@riverpod
+class BudgetsController extends _$BudgetsController {
+  @override
+  AsyncValue<void> build() => const AsyncData(null);
+
+  Future<bool> save({String? id, required BudgetRequest request}) => _run(() async {
+    final budgets = ref.read(apiProvider).getBudgetsApi();
+
+    if (id == null) {
+      await budgets.createBudget(budgetRequest: request).orApiError();
+    } else {
+      await budgets.updateBudget(id: id, budgetRequest: request).orApiError();
+    }
+  });
+
+  /// Budgets are archived rather than deleted, so the history they hold survives.
+  Future<bool> archive(String id) =>
+      _run(() => ref.read(apiProvider).getBudgetsApi().archiveBudget(id: id).orApiError());
+
+  Future<bool> _run(Future<void> Function() write) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(write);
+
+    if (state.hasError) return false;
+
+    ref.invalidate(budgetSummaryProvider);
+
+    return true;
+  }
+}

--- a/mobile/lib/budgets/budgets_controller.g.dart
+++ b/mobile/lib/budgets/budgets_controller.g.dart
@@ -1,0 +1,71 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'budgets_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Writing budgets. Every write re-reads the summary rather than patching the list: changing one
+/// budget's allocation moves what is left on Spendable, so the row that came back is not the only
+/// one that changed.
+
+@ProviderFor(BudgetsController)
+final budgetsControllerProvider = BudgetsControllerProvider._();
+
+/// Writing budgets. Every write re-reads the summary rather than patching the list: changing one
+/// budget's allocation moves what is left on Spendable, so the row that came back is not the only
+/// one that changed.
+final class BudgetsControllerProvider extends $NotifierProvider<BudgetsController, AsyncValue<void>> {
+  /// Writing budgets. Every write re-reads the summary rather than patching the list: changing one
+  /// budget's allocation moves what is left on Spendable, so the row that came back is not the only
+  /// one that changed.
+  BudgetsControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetsControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetsControllerHash();
+
+  @$internal
+  @override
+  BudgetsController create() => BudgetsController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<void> value) {
+    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<AsyncValue<void>>(value));
+  }
+}
+
+String _$budgetsControllerHash() => r'6671da06601d978aee7ee7eb9c1c922ffb07d5a9';
+
+/// Writing budgets. Every write re-reads the summary rather than patching the list: changing one
+/// budget's allocation moves what is left on Spendable, so the row that came back is not the only
+/// one that changed.
+
+abstract class _$BudgetsController extends $Notifier<AsyncValue<void>> {
+  AsyncValue<void> build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<void>, AsyncValue<void>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<void>, AsyncValue<void>>,
+              AsyncValue<void>,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/mobile/lib/budgets/budgets_providers.dart
+++ b/mobile/lib/budgets/budgets_providers.dart
@@ -1,0 +1,56 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:spendable_api/spendable_api.dart';
+
+import '../api/api_client.dart';
+import '../api/api_error.dart';
+import '../money.dart';
+
+part 'budgets_providers.g.dart';
+
+/// The id given to the synthetic Credit Cards card, which is not a budget and has no row.
+const creditCardsId = 'credit-cards';
+
+/// Null leaves the choice to the server, which answers for the current month.
+@riverpod
+class SelectedMonth extends _$SelectedMonth {
+  @override
+  Date? build() => null;
+
+  void select(Date month) => state = month;
+}
+
+@riverpod
+class BudgetSearch extends _$BudgetSearch {
+  @override
+  String? build() => null;
+
+  void set(String term) => state = term.isEmpty ? null : term;
+}
+
+@riverpod
+Future<BudgetSummary> budgetSummary(Ref ref) async {
+  final response = await ref
+      .watch(apiProvider)
+      .getBudgetsApi()
+      .getBudgetSummary(month: ref.watch(selectedMonthProvider), search: ref.watch(budgetSearchProvider))
+      .orApiError();
+
+  return response.data!;
+}
+
+/// Card debt is not a budget, but it reads as one on this screen: a negative balance to cover.
+/// It only makes sense against the current month, since it is what is owed right now.
+List<Budget> listedBudgets(BudgetSummary summary) {
+  if (!summary.currentMonth || summary.budgets.isEmpty) return summary.budgets.toList();
+
+  final creditCards = Budget(
+    (builder) => builder
+      ..id = creditCardsId
+      ..name = 'Credit Cards'
+      ..type = BudgetTypeEnum.envelope
+      ..balance = (-money(summary.creditCardBalance)).toString(),
+  );
+
+  // Spendable stays first; the card total sits beside it.
+  return [summary.budgets.first, creditCards, ...summary.budgets.skip(1)];
+}

--- a/mobile/lib/budgets/budgets_providers.g.dart
+++ b/mobile/lib/budgets/budgets_providers.g.dart
@@ -1,0 +1,131 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'budgets_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Null leaves the choice to the server, which answers for the current month.
+
+@ProviderFor(SelectedMonth)
+final selectedMonthProvider = SelectedMonthProvider._();
+
+/// Null leaves the choice to the server, which answers for the current month.
+final class SelectedMonthProvider extends $NotifierProvider<SelectedMonth, Date?> {
+  /// Null leaves the choice to the server, which answers for the current month.
+  SelectedMonthProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'selectedMonthProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$selectedMonthHash();
+
+  @$internal
+  @override
+  SelectedMonth create() => SelectedMonth();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Date? value) {
+    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<Date?>(value));
+  }
+}
+
+String _$selectedMonthHash() => r'aab73e649f6bc3b895dc03ad2ff7354ee2298cd9';
+
+/// Null leaves the choice to the server, which answers for the current month.
+
+abstract class _$SelectedMonth extends $Notifier<Date?> {
+  Date? build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<Date?, Date?>;
+    final element = ref.element as $ClassProviderElement<AnyNotifier<Date?, Date?>, Date?, Object?, Object?>;
+    return element.handleCreate(ref, build);
+  }
+}
+
+@ProviderFor(BudgetSearch)
+final budgetSearchProvider = BudgetSearchProvider._();
+
+final class BudgetSearchProvider extends $NotifierProvider<BudgetSearch, String?> {
+  BudgetSearchProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetSearchProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetSearchHash();
+
+  @$internal
+  @override
+  BudgetSearch create() => BudgetSearch();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(String? value) {
+    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<String?>(value));
+  }
+}
+
+String _$budgetSearchHash() => r'b0b421d77d5fccbd97674c766dcba50a9b30957a';
+
+abstract class _$BudgetSearch extends $Notifier<String?> {
+  String? build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<String?, String?>;
+    final element =
+        ref.element as $ClassProviderElement<AnyNotifier<String?, String?>, String?, Object?, Object?>;
+    return element.handleCreate(ref, build);
+  }
+}
+
+@ProviderFor(budgetSummary)
+final budgetSummaryProvider = BudgetSummaryProvider._();
+
+final class BudgetSummaryProvider
+    extends $FunctionalProvider<AsyncValue<BudgetSummary>, BudgetSummary, FutureOr<BudgetSummary>>
+    with $FutureModifier<BudgetSummary>, $FutureProvider<BudgetSummary> {
+  BudgetSummaryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetSummaryProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetSummaryHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<BudgetSummary> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<BudgetSummary> create(Ref ref) {
+    return budgetSummary(ref);
+  }
+}
+
+String _$budgetSummaryHash() => r'1605faaf2008480baa76429a5292bbcccd393c08';

--- a/mobile/lib/budgets/budgets_screen.dart
+++ b/mobile/lib/budgets/budgets_screen.dart
@@ -1,0 +1,355 @@
+import 'package:decimal/decimal.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spendable_api/spendable_api.dart';
+
+import '../auth/account_screen.dart';
+import '../money.dart';
+import '../theme.dart';
+import 'budget_card.dart';
+import 'budget_form.dart';
+import 'budgets_providers.dart';
+
+const _months = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+String monthName(Date month) => '${_months[month.month - 1]} ${month.year}';
+
+class BudgetsScreen extends ConsumerWidget {
+  const BudgetsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final summary = ref.watch(budgetSummaryProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: switch (summary) {
+          AsyncData(value: final summary) => _MonthPicker(summary: summary),
+          _ => const Text('Budgets'),
+        },
+        actions: [
+          IconButton(
+            key: const Key('open-account'),
+            icon: const Icon(Icons.person_outline),
+            onPressed: () =>
+                Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => const AccountScreen())),
+          ),
+          IconButton(
+            key: const Key('new-budget'),
+            icon: const Icon(Icons.add),
+            onPressed: () => openBudgetForm(context),
+          ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: () async => ref.invalidate(budgetSummaryProvider),
+        child: switch (summary) {
+          AsyncData(value: final summary) => _Budgets(summary: summary),
+          AsyncError(:final error) => _Retry(message: '$error'),
+          _ => const Center(child: CircularProgressIndicator()),
+        },
+      ),
+    );
+  }
+}
+
+Future<void> openBudgetForm(BuildContext context, {Budget? budget}) => showModalBottomSheet<void>(
+  context: context,
+  isScrollControlled: true,
+  builder: (_) => BudgetForm(budget: budget),
+);
+
+class _MonthPicker extends ConsumerWidget {
+  const _MonthPicker({required this.summary});
+
+  final BudgetSummary summary;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return PopupMenuButton<Date>(
+      key: const Key('month-picker'),
+      onSelected: (month) => ref.read(selectedMonthProvider.notifier).select(month),
+      itemBuilder: (_) => [
+        for (final entry in summary.spentByMonth)
+          PopupMenuItem(
+            value: entry.month,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(monthName(entry.month)),
+                Text(
+                  'spent: ${formatCurrency(money(entry.spent))}',
+                  style: const TextStyle(color: SpendableColors.muted, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+      ],
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(monthName(summary.month), style: Theme.of(context).textTheme.titleLarge),
+          const Icon(Icons.unfold_more, size: 18, color: SpendableColors.muted),
+        ],
+      ),
+    );
+  }
+}
+
+class _Budgets extends StatelessWidget {
+  const _Budgets({required this.summary});
+
+  final BudgetSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final budgets = listedBudgets(summary);
+
+    return ListView.separated(
+      padding: const EdgeInsets.only(bottom: 24),
+      itemCount: budgets.length + 1,
+      separatorBuilder: (_, _) => const SizedBox(height: 8),
+      itemBuilder: (context, index) {
+        if (index == 0) return _Totals(summary: summary);
+
+        final budget = budgets[index - 1];
+
+        return _Card(
+          budget: budget,
+          spent: money(summary.spent[budget.id] ?? '0').abs(),
+          currentMonth: summary.currentMonth,
+        );
+      },
+    );
+  }
+}
+
+class _Totals extends StatelessWidget {
+  const _Totals({required this.summary});
+
+  final BudgetSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final spendable = money(summary.spendable);
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: Colors.white10)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          if (summary.currentMonth)
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const _Caption('Spendable'),
+                  Text(
+                    formatCurrency(spendable),
+                    key: const Key('spendable-total'),
+                    style: TextStyle(
+                      fontSize: 34,
+                      fontWeight: FontWeight.w600,
+                      color: spendable.sign < 0 ? SpendableColors.negative : SpendableColors.positive,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          if (summary.currentMonth) _Total(label: 'Allocated', amount: money(summary.allocatedTotal)),
+          const SizedBox(width: 24),
+          _Total(label: 'Spent', amount: money(summary.spentTotal)),
+        ],
+      ),
+    );
+  }
+}
+
+class _Total extends StatelessWidget {
+  const _Total({required this.label, required this.amount});
+
+  final String label;
+  final Decimal amount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Text(formatCurrency(amount), style: const TextStyle(fontSize: 22, fontWeight: FontWeight.w600)),
+        _Caption(label),
+      ],
+    );
+  }
+}
+
+class _Caption extends StatelessWidget {
+  const _Caption(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text.toUpperCase(),
+      style: const TextStyle(color: SpendableColors.muted, fontSize: 11, letterSpacing: 0.8),
+    );
+  }
+}
+
+class _Card extends StatelessWidget {
+  const _Card({required this.budget, required this.spent, required this.currentMonth});
+
+  static const _barColors = {
+    CardBar.under: SpendableColors.accent,
+    CardBar.over: SpendableColors.negative,
+    CardBar.goal: SpendableColors.positive,
+  };
+
+  final Budget budget;
+  final Decimal spent;
+  final bool currentMonth;
+
+  @override
+  Widget build(BuildContext context) {
+    final card = BudgetCard.build(budget: budget, spent: spent, currentMonth: currentMonth);
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      color: SpendableColors.surface,
+      child: InkWell(
+        // The credit card total is a reading of the bank accounts, not a row anyone can edit.
+        onTap: budget.id == creditCardsId ? null : () => openBudgetForm(context, budget: budget),
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      budget.name,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                  _Pill(type: budget.type),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text(
+                    formatCurrency(card.amount),
+                    key: Key('amount-${budget.id}'),
+                    style: TextStyle(
+                      fontSize: 28,
+                      fontWeight: FontWeight.w600,
+                      color: card.amount.sign < 0 ? SpendableColors.negative : Colors.white,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  _Caption(card.label),
+                ],
+              ),
+              if (card.percent case final percent?) ...[
+                const SizedBox(height: 12),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(2),
+                  child: LinearProgressIndicator(
+                    key: Key('bar-${budget.id}'),
+                    value: percent / 100,
+                    minHeight: 4,
+                    backgroundColor: Colors.white10,
+                    valueColor: AlwaysStoppedAnimation(_barColors[card.bar]),
+                  ),
+                ),
+              ],
+              if (card.footer case final footer?) ...[
+                const SizedBox(height: 10),
+                Text(footer, style: const TextStyle(color: SpendableColors.muted, fontSize: 12)),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Pill extends StatelessWidget {
+  const _Pill({required this.type});
+
+  static const _labels = {
+    BudgetTypeEnum.envelope: ('Envelope', SpendableColors.accent),
+    BudgetTypeEnum.goal: ('Goal', SpendableColors.positive),
+    BudgetTypeEnum.tracking: ('Tracking', SpendableColors.muted),
+  };
+
+  final BudgetTypeEnum type;
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, color) = _labels[type] ?? ('Envelope', SpendableColors.accent);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(color: color, fontSize: 11, fontWeight: FontWeight.w500),
+      ),
+    );
+  }
+}
+
+class _Retry extends ConsumerWidget {
+  const _Retry({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListView(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            children: [
+              Text(message, textAlign: TextAlign.center),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: () => ref.invalidate(budgetSummaryProvider),
+                child: const Text('Try again'),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/money.dart
+++ b/mobile/lib/money.dart
@@ -1,0 +1,29 @@
+import 'package:decimal/decimal.dart';
+
+/// Amounts cross the wire as decimal strings, so they stay exact rather than becoming doubles.
+Decimal money(String value) => Decimal.parse(value);
+
+/// Mirrors `Spendable.Utils.format_currency/1`, which the web app renders with. Kept in step by
+/// shared/budget_cards.json.
+String formatCurrency(Decimal? amount) {
+  if (amount == null) return r'$0.00';
+
+  final text = amount.abs().round(scale: 2).toStringAsFixed(2);
+  final dot = text.lastIndexOf('.');
+  final sign = amount.sign < 0 ? r'-$' : r'$';
+
+  return '$sign${_grouped(text.substring(0, dot))}${text.substring(dot)}';
+}
+
+String _grouped(String dollars) {
+  final digits = dollars.split('').reversed.toList();
+  final chunks = <String>[];
+
+  for (var start = 0; start < digits.length; start += 3) {
+    final end = start + 3 < digits.length ? start + 3 : digits.length;
+
+    chunks.add(digits.sublist(start, end).join());
+  }
+
+  return chunks.join(',').split('').reversed.join();
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -185,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.12"
+  decimal:
+    dependency: "direct main"
+    description:
+      name: decimal
+      sha256: "2c3c8b74f2948066d3f42585477aec9cfc48fefd7a723a4d4274a6c71a5c0df7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.6"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -448,6 +456,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -728,6 +744,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  rational:
+    dependency: transitive
+    description:
+      name: rational
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   record_use:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
+  decimal: ^3.2.6
   device_info_plus: ^13.2.0
   dio: ^5.11.0
   flutter:

--- a/mobile/test/budgets/budget_card_test.dart
+++ b/mobile/test/budgets/budget_card_test.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:decimal/decimal.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spendable/budgets/budget_card.dart';
+import 'package:spendable/money.dart';
+import 'package:spendable_api/spendable_api.dart';
+
+/// The same table `lib/spendable_web/utils/budget_card_test.exs` runs, so a change to either
+/// side that the other did not follow fails here.
+final _fixtures = jsonDecode(File('../shared/budget_cards.json').readAsStringSync()) as Map<String, dynamic>;
+
+const _bars = {'under': CardBar.under, 'over': CardBar.over, 'goal': CardBar.goal};
+
+void main() {
+  for (final entry in _fixtures['cards'] as List) {
+    final fixture = entry as Map<String, dynamic>;
+    final expected = fixture['card'] as Map<String, dynamic>;
+    final source = fixture['budget'] as Map<String, dynamic>;
+
+    test(fixture['name'] as String, () {
+      final budget = Budget(
+        (builder) => builder
+          ..id = 'bgt_fixture'
+          ..name = 'Fixture'
+          ..type = BudgetTypeEnum.valueOf(source['type'] as String)
+          ..balance = source['balance'] as String
+          ..budgetedAmount = source['budgeted_amount'] as String?,
+      );
+
+      final card = BudgetCard.build(
+        budget: budget,
+        spent: money(fixture['spent'] as String),
+        currentMonth: fixture['current_month'] as bool,
+      );
+
+      expect(card.label, expected['label']);
+      expect(card.percent, expected['percent']);
+      expect(card.bar, _bars[expected['bar']]);
+      expect(card.footer, expected['footer']);
+      expect(card.amount, money(expected['amount'] as String));
+    });
+  }
+
+  for (final entry in _fixtures['currency'] as List) {
+    final fixture = entry as Map<String, dynamic>;
+    final amount = fixture['amount'] as String?;
+
+    test('formats ${amount ?? 'nothing'} as ${fixture['formatted']}', () {
+      expect(formatCurrency(amount == null ? null : Decimal.parse(amount)), fixture['formatted']);
+    });
+  }
+}

--- a/mobile/test/budgets/budgets_screen_test.dart
+++ b/mobile/test/budgets/budgets_screen_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spendable/api/api_client.dart';
+import 'package:spendable/budgets/budgets_screen.dart';
+
+import '../support/fakes.dart';
+
+Map<String, Object?> _budget(
+  String id,
+  String name, {
+  String type = 'envelope',
+  String balance = '0.00',
+  String? budgetedAmount,
+}) => {
+  'id': id,
+  'name': name,
+  'type': type,
+  'balance': balance,
+  'budgeted_amount': budgetedAmount,
+  'archived_at': null,
+};
+
+Map<String, Object?> _summary({
+  bool currentMonth = true,
+  String creditCardBalance = '0.00',
+  List<Map<String, Object?>>? budgets,
+  Map<String, String>? spent,
+}) => {
+  'month': '2026-08-01',
+  'current_month': currentMonth,
+  'spendable': '420.00',
+  'allocated_total': '1000.00',
+  'spent_total': '250.00',
+  'credit_card_balance': creditCardBalance,
+  'budgets':
+      budgets ??
+      [
+        _budget('bgt_spendable', 'Spendable'),
+        _budget('bgt_food', 'Food', balance: '50.00', budgetedAmount: '200.00'),
+      ],
+  'spent': spent ?? {'bgt_spendable': '0.00', 'bgt_food': '-150.00'},
+  'spent_by_month': [
+    {'month': '2026-08-01', 'spent': '-250.00'},
+    {'month': '2026-07-01', 'spent': '-310.00'},
+  ],
+};
+
+Future<FakeApi> _pump(WidgetTester tester, {Map<String, ({int status, Object? body})>? replies}) async {
+  final api = FakeApi(replies ?? {'GET /api/budgets/summary': (status: 200, body: _summary())});
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [apiProvider.overrideWithValue(api.build())],
+      child: const MaterialApp(home: BudgetsScreen()),
+    ),
+  );
+
+  await tester.pumpAndSettle();
+
+  return api;
+}
+
+void main() {
+  testWidgets('shows the month and the totals behind it', (tester) async {
+    await _pump(tester);
+
+    expect(find.text('August 2026'), findsOneWidget);
+    expect(find.byKey(const Key('spendable-total')), findsOneWidget);
+    expect(find.text(r'$420.00'), findsOneWidget);
+    expect(find.text(r'$1,000.00'), findsOneWidget);
+  });
+
+  testWidgets('renders a card per budget with its label and footer', (tester) async {
+    await _pump(tester);
+
+    expect(find.text('Food'), findsOneWidget);
+    expect(find.text('LEFT'), findsWidgets);
+    expect(find.text(r'$150.00 of $200.00 spent'), findsOneWidget);
+  });
+
+  // Card debt reads as a budget here, but only against the current month.
+  testWidgets('slots credit cards in behind Spendable as a negative balance', (tester) async {
+    await _pump(
+      tester,
+      replies: {'GET /api/budgets/summary': (status: 200, body: _summary(creditCardBalance: '325.50'))},
+    );
+
+    expect(find.text('Credit Cards'), findsOneWidget);
+    expect(find.text(r'-$325.50'), findsOneWidget);
+  });
+
+  testWidgets('leaves credit cards off a past month', (tester) async {
+    await _pump(
+      tester,
+      replies: {
+        'GET /api/budgets/summary': (
+          status: 200,
+          body: _summary(currentMonth: false, creditCardBalance: '325.50'),
+        ),
+      },
+    );
+
+    expect(find.text('Credit Cards'), findsNothing);
+    expect(find.byKey(const Key('spendable-total')), findsNothing);
+  });
+
+  testWidgets('picking a month re-reads the summary for it', (tester) async {
+    final api = await _pump(tester);
+
+    await tester.tap(find.byKey(const Key('month-picker')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('July 2026'));
+    await tester.pumpAndSettle();
+
+    expect(api.requests.last.queryParameters['month'], '2026-07-01');
+  });
+
+  testWidgets('saving a budget re-reads the whole summary, not just the row', (tester) async {
+    final api = await _pump(
+      tester,
+      replies: {
+        'GET /api/budgets/summary': (status: 200, body: _summary()),
+        'PATCH /api/budgets/bgt_food': (
+          status: 200,
+          body: _budget('bgt_food', 'Groceries', balance: '50.00', budgetedAmount: '200.00'),
+        ),
+      },
+    );
+
+    await tester.tap(find.text('Food'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const Key('budget-name')), 'Groceries');
+    await tester.tap(find.byKey(const Key('budget-save')));
+    await tester.pumpAndSettle();
+
+    expect(api.requests.map((request) => '${request.method} ${request.path}'), [
+      'GET /api/budgets/summary',
+      'PATCH /api/budgets/bgt_food',
+      'GET /api/budgets/summary',
+    ]);
+  });
+
+  testWidgets('a rejected save keeps the sheet open with the error on the field', (tester) async {
+    await _pump(
+      tester,
+      replies: {
+        'GET /api/budgets/summary': (status: 200, body: _summary()),
+        'PATCH /api/budgets/bgt_food': (
+          status: 422,
+          body: {
+            'errors': [
+              {
+                'code': 'invalid',
+                'detail': "can't be blank",
+                'source': {'pointer': '/name'},
+              },
+            ],
+          },
+        ),
+      },
+    );
+
+    await tester.tap(find.text('Food'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const Key('budget-name')), '');
+    await tester.tap(find.byKey(const Key('budget-save')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('budget-save')), findsOneWidget);
+    expect(find.text("can't be blank"), findsOneWidget);
+  });
+
+  testWidgets('the credit card total is not editable', (tester) async {
+    await _pump(
+      tester,
+      replies: {'GET /api/budgets/summary': (status: 200, body: _summary(creditCardBalance: '325.50'))},
+    );
+
+    await tester.tap(find.text('Credit Cards'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('budget-save')), findsNothing);
+  });
+}

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,2797 @@
+{
+  "components": {
+    "responses": {},
+    "schemas": {
+      "BankAccount": {
+        "description": "An account inside a connection. Amounts are decimal strings.",
+        "properties": {
+          "balance": {
+            "description": "Negative on a credit card, as a ledger reads.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "budget_id": {
+            "description": "When set, this account's balance is that budget's balance.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "number": {
+            "description": "Masked, last digits only.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "sub_type": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "sync": {
+            "description": "Whether activity is pulled and counted.",
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "type": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "sub_type",
+          "balance",
+          "sync"
+        ],
+        "title": "BankAccount",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.BankAccount",
+        "x-validate": null
+      },
+      "BankAccountRequest": {
+        "description": "The two things a user decides about an account: whether to sync it, and where it belongs.",
+        "example": {
+          "budget_id": "bgt_01j0rent",
+          "sync": true
+        },
+        "properties": {
+          "budget_id": {
+            "description": "Null unassigns, putting the balance back into Spendable.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "sync": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "title": "BankAccountRequest",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.BankAccountRequest",
+        "x-validate": null
+      },
+      "BankMember": {
+        "description": "A connection to an institution, and the accounts inside it.",
+        "properties": {
+          "bank_accounts": {
+            "items": {
+              "$ref": "#/components/schemas/BankAccount"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "has_logo": {
+            "description": "Fetch it from `/api/banks/{id}/logo` when true.",
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "provider": {
+            "description": "Who supplies the connection.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "status": {
+            "description": "Anything other than \"CONNECTED\" means the user has to reconnect.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "provider",
+          "has_logo",
+          "bank_accounts"
+        ],
+        "title": "BankMember",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.BankMember",
+        "x-validate": null
+      },
+      "Budget": {
+        "description": "An envelope money is divided into. Amounts are decimal strings.",
+        "properties": {
+          "archived_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "balance": {
+            "description": "What the allocations add up to, or the bank account's balance when assigned.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "budgeted_amount": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "type": {
+            "enum": [
+              "tracking",
+              "envelope",
+              "goal"
+            ],
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "balance"
+        ],
+        "title": "Budget",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.Budget",
+        "x-validate": null
+      },
+      "BudgetAllocation": {
+        "description": "One budget's share of a transaction.",
+        "properties": {
+          "amount": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "budget_id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "amount",
+          "budget_id"
+        ],
+        "title": "BudgetAllocation",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.BudgetAllocation",
+        "x-validate": null
+      },
+      "BudgetAllocationRequest": {
+        "description": "An allocation to keep, update or add. Distinct from BudgetAllocation because `id` is optional.\n",
+        "properties": {
+          "amount": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "budget_id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "description": "Omit to add a new allocation.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "amount",
+          "budget_id"
+        ],
+        "title": "BudgetAllocationRequest",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.BudgetAllocationRequest",
+        "x-validate": null
+      },
+      "BudgetRequest": {
+        "description": "Amounts are decimal strings. `balance` is what the user wants the budget to hold - the server\nworks out the adjustment that gets it there, so never send `adjustment`.\n",
+        "example": {
+          "budgeted_amount": "400.00",
+          "name": "Groceries",
+          "type": "envelope"
+        },
+        "properties": {
+          "balance": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "budgeted_amount": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "type": {
+            "enum": [
+              "tracking",
+              "envelope",
+              "goal"
+            ],
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "title": "BudgetRequest",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.BudgetRequest",
+        "x-validate": null
+      },
+      "BudgetSummary": {
+        "description": "Everything the budgets screen shows for one month. Presentation is the client's - this is the\nnumbers behind it.\n",
+        "properties": {
+          "allocated_total": {
+            "description": "Budgeted across envelopes.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "budgets": {
+            "items": {
+              "$ref": "#/components/schemas/Budget"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "credit_card_balance": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "current_month": {
+            "description": "Spendable, allocated and credit cards only apply to the current month.",
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "month": {
+            "format": "date",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "spendable": {
+            "description": "Synced money no budget has claimed.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "spent": {
+            "additionalProperties": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            },
+            "description": "Spent this month, keyed by budget id. Every listed budget has an entry.",
+            "type": "object",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "spent_by_month": {
+            "description": "Newest first, for the month picker.",
+            "items": {
+              "$ref": "#/components/schemas/MonthSpend"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "spent_total": {
+            "description": "Spent across envelopes this month.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "month",
+          "current_month",
+          "spendable",
+          "allocated_total",
+          "spent_total",
+          "credit_card_balance",
+          "budgets",
+          "spent",
+          "spent_by_month"
+        ],
+        "title": "BudgetSummary",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.BudgetSummary",
+        "x-validate": null
+      },
+      "BulkFailure": {
+        "description": "One transaction a bulk change did not apply to, and why.",
+        "properties": {
+          "code": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "code"
+        ],
+        "title": "BulkFailure",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.BulkFailure",
+        "x-validate": null
+      },
+      "BulkRequest": {
+        "description": "Applies the same change to several transactions. `budget_id` spends each transaction's whole\namount from that budget, replacing whatever it was allocated to before.\n",
+        "example": {
+          "reviewed": true,
+          "transaction_ids": [
+            "txn_01j0one",
+            "txn_01j0two"
+          ]
+        },
+        "properties": {
+          "budget_id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "excluded": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "reviewed": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "transaction_ids": {
+            "items": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            },
+            "minItems": 1,
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "transaction_ids"
+        ],
+        "title": "BulkRequest",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.BulkRequest",
+        "x-validate": null
+      },
+      "BulkResult": {
+        "description": "A bulk change is applied per transaction rather than all or nothing, so the ones that worked\ncome back alongside the ones that did not.\n",
+        "properties": {
+          "failed": {
+            "items": {
+              "$ref": "#/components/schemas/BulkFailure"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "transactions": {
+            "items": {
+              "$ref": "#/components/schemas/Transaction"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "transactions",
+          "failed"
+        ],
+        "title": "BulkResult",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.BulkResult",
+        "x-validate": null
+      },
+      "ConnectRequest": {
+        "description": "The public token Plaid Link returns once the user has picked a bank.",
+        "properties": {
+          "public_token": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "public_token"
+        ],
+        "title": "ConnectRequest",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.ConnectRequest",
+        "x-validate": null
+      },
+      "Errors": {
+        "description": "The shape every failed request comes back in.",
+        "properties": {
+          "errors": {
+            "items": {
+              "properties": {
+                "code": {
+                  "description": "Machine-readable reason.",
+                  "type": "string",
+                  "x-struct": null,
+                  "x-validate": null
+                },
+                "detail": {
+                  "type": "string",
+                  "x-struct": null,
+                  "x-validate": null
+                },
+                "source": {
+                  "description": "Present on validation errors, pointing at the offending field.",
+                  "properties": {
+                    "pointer": {
+                      "type": "string",
+                      "x-struct": null,
+                      "x-validate": null
+                    }
+                  },
+                  "type": "object",
+                  "x-struct": null,
+                  "x-validate": null
+                }
+              },
+              "required": [
+                "code",
+                "detail"
+              ],
+              "type": "object",
+              "x-struct": null,
+              "x-validate": null
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "errors"
+        ],
+        "title": "Errors",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.Errors",
+        "x-validate": null
+      },
+      "Identity": {
+        "description": "A way of signing into an account.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "provider": {
+            "enum": [
+              "apple",
+              "google"
+            ],
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "provider"
+        ],
+        "title": "Identity",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.Identity",
+        "x-validate": null
+      },
+      "LinkToken": {
+        "description": "Hand this to the Plaid Link SDK. Short-lived.",
+        "properties": {
+          "link_token": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "link_token"
+        ],
+        "title": "LinkToken",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.LinkToken",
+        "x-validate": null
+      },
+      "MonthSpend": {
+        "description": "A month the user has spent in, for the month picker.",
+        "properties": {
+          "month": {
+            "format": "date",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "spent": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "month",
+          "spent"
+        ],
+        "title": "MonthSpend",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.MonthSpend",
+        "x-validate": null
+      },
+      "Session": {
+        "description": "An API token. The token itself is returned once and never again.",
+        "properties": {
+          "device_name": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "expires_at": {
+            "format": "date-time",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "token": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "token",
+          "expires_at"
+        ],
+        "title": "Session",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.Session",
+        "x-validate": null
+      },
+      "SessionRequest": {
+        "description": "An ID token from a native sign-in, exchanged for an API token.",
+        "example": {
+          "device_name": "iPhone",
+          "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMyJ9.eyJzdWIiOiI0MiJ9.signature",
+          "provider": "google"
+        },
+        "properties": {
+          "device_name": {
+            "description": "Shown when managing signed-in devices.",
+            "maxLength": 100,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id_token": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "provider": {
+            "enum": [
+              "apple",
+              "google"
+            ],
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "provider",
+          "id_token"
+        ],
+        "title": "SessionRequest",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.SessionRequest",
+        "x-validate": null
+      },
+      "Split": {
+        "description": "A saved division of a transaction across budgets. Amounts are decimal strings.",
+        "properties": {
+          "archived_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "split_lines": {
+            "description": "Oldest first.",
+            "items": {
+              "$ref": "#/components/schemas/SplitLine"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "split_lines"
+        ],
+        "title": "Split",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.Split",
+        "x-validate": null
+      },
+      "SplitLine": {
+        "description": "One budget's share of a split.",
+        "properties": {
+          "amount": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "budget_id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "amount",
+          "budget_id"
+        ],
+        "title": "SplitLine",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.SplitLine",
+        "x-validate": null
+      },
+      "SplitLineRequest": {
+        "description": "A line to keep, update or add. Distinct from SplitLine because `id` is optional.",
+        "properties": {
+          "amount": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "budget_id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "description": "Omit to add a new line.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "amount",
+          "budget_id"
+        ],
+        "title": "SplitLineRequest",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.SplitLineRequest",
+        "x-validate": null
+      },
+      "SplitRequest": {
+        "description": "Send the whole set of lines you want the split to end up with. A line with an `id` is kept and\nupdated, one without is added, and any line left out is deleted.\n",
+        "example": {
+          "name": "Payday",
+          "split_lines": [
+            {
+              "amount": "-200.00",
+              "budget_id": "bgt_01j0rent"
+            }
+          ]
+        },
+        "properties": {
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "split_lines": {
+            "items": {
+              "$ref": "#/components/schemas/SplitLineRequest"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "title": "SplitRequest",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.SplitRequest",
+        "x-validate": null
+      },
+      "Transaction": {
+        "description": "A movement of money. Amounts are decimal strings, negative for money going out.\n\n`budget_allocations` is what the server settled on, not what was sent: any part of the amount\nleft unallocated lands on the Spendable budget on every write. Render what comes back.\n",
+        "properties": {
+          "amount": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "budget_allocations": {
+            "items": {
+              "$ref": "#/components/schemas/BudgetAllocation"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "date": {
+            "format": "date",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "excluded": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "note": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "reviewed": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "source": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TransactionSource"
+              }
+            ],
+            "x-struct": null,
+            "x-validate": null
+          },
+          "transfer_id": {
+            "description": "The other side of a move between the user's own accounts.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "amount",
+          "date",
+          "reviewed",
+          "excluded",
+          "budget_allocations"
+        ],
+        "title": "Transaction",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.Transaction",
+        "x-validate": null
+      },
+      "TransactionRequest": {
+        "description": "Send the whole set of allocations you want. One with an `id` is kept and updated, one without\nis added, one left out is deleted. Whatever is left of the amount goes to Spendable, so the\nallocations in the response are the ones that count.\n\nThat also means a validation error's pointer indexes the list the server settled on, not the\none that was sent - match the offending line by its `budget_id`, not by position.\n",
+        "example": {
+          "amount": "-30.00",
+          "budget_allocations": [
+            {
+              "amount": "-30.00",
+              "budget_id": "bgt_01j0groceries"
+            }
+          ],
+          "date": "2026-08-15",
+          "name": "Market"
+        },
+        "properties": {
+          "amount": {
+            "description": "Negative for money going out.",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "budget_allocations": {
+            "items": {
+              "$ref": "#/components/schemas/BudgetAllocationRequest"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "date": {
+            "format": "date",
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "excluded": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "note": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "reviewed": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "title": "TransactionRequest",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.TransactionRequest",
+        "x-validate": null
+      },
+      "TransactionSource": {
+        "description": "Where a synced transaction came from, flattened for the list row. Null on a transaction the\nuser entered themselves. Fetch the logo from `/api/banks/{member_id}/logo`.\n",
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "account_name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "account_number": {
+            "description": "Masked, last digits only.",
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "member_has_logo": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "member_id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "member_name": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "pending": {
+            "type": "boolean",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "account_id",
+          "account_name",
+          "member_id",
+          "member_name",
+          "member_has_logo",
+          "pending"
+        ],
+        "title": "TransactionSource",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.TransactionSource",
+        "x-validate": null
+      },
+      "TransferRequest": {
+        "description": "Exactly two transactions: one leaving an account and one arriving in another.",
+        "example": {
+          "transaction_ids": [
+            "txn_01j0out",
+            "txn_01j0in"
+          ]
+        },
+        "properties": {
+          "transaction_ids": {
+            "items": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            },
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "transaction_ids"
+        ],
+        "title": "TransferRequest",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.TransferRequest",
+        "x-validate": null
+      },
+      "User": {
+        "description": "The signed-in user.",
+        "properties": {
+          "bank_limit": {
+            "description": "How many banks the user may connect.",
+            "type": "integer",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "id": {
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "identities": {
+            "description": "The ways this account can be signed into.",
+            "items": {
+              "$ref": "#/components/schemas/Identity"
+            },
+            "type": "array",
+            "x-struct": null,
+            "x-validate": null
+          },
+          "image": {
+            "nullable": true,
+            "type": "string",
+            "x-struct": null,
+            "x-validate": null
+          }
+        },
+        "required": [
+          "id",
+          "bank_limit",
+          "identities"
+        ],
+        "title": "User",
+        "type": "object",
+        "x-struct": "Elixir.SpendableWeb.Api.Schemas.User",
+        "x-validate": null
+      }
+    },
+    "securitySchemes": {
+      "bearer": {
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "description": "The API the Spendable mobile app runs on.",
+    "title": "Spendable",
+    "version": "1.0.0"
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/bank_accounts/{id}": {
+      "patch": {
+        "callbacks": {},
+        "operationId": "updateBankAccount",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BankAccountRequest"
+              }
+            }
+          },
+          "description": "BankAccount",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BankAccount"
+                }
+              }
+            },
+            "description": "BankAccount"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Sync an account, or assign it to a budget",
+        "tags": [
+          "banks"
+        ]
+      }
+    },
+    "/api/banks": {
+      "get": {
+        "callbacks": {},
+        "operationId": "listBanks",
+        "parameters": [
+          {
+            "description": "Matches on institution name.",
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/BankMember"
+                  },
+                  "type": "array",
+                  "x-struct": null,
+                  "x-validate": null
+                }
+              }
+            },
+            "description": "BankMembers"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "List connections and their accounts",
+        "tags": [
+          "banks"
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "description": "Exchanges the public token Plaid Link returned. The accounts arrive on the first sync rather\nthan in this response, so the connection comes back with none.\n",
+        "operationId": "createBank",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectRequest"
+              }
+            }
+          },
+          "description": "Public token",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BankMember"
+                }
+              }
+            },
+            "description": "BankMember"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Finish connecting a bank",
+        "tags": [
+          "banks"
+        ]
+      }
+    },
+    "/api/banks/link_token": {
+      "post": {
+        "callbacks": {},
+        "description": "Refused once the user is at their bank limit, before Plaid is called.",
+        "operationId": "createLinkToken",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LinkToken"
+                }
+              }
+            },
+            "description": "LinkToken"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Start connecting a bank",
+        "tags": [
+          "banks"
+        ]
+      }
+    },
+    "/api/banks/{id}/link_token": {
+      "post": {
+        "callbacks": {},
+        "description": "For a connection whose status is not CONNECTED, or to verify micro deposits.",
+        "operationId": "createUpdateLinkToken",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LinkToken"
+                }
+              }
+            },
+            "description": "LinkToken"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Reopen an existing connection",
+        "tags": [
+          "banks"
+        ]
+      }
+    },
+    "/api/banks/{id}/logo": {
+      "get": {
+        "callbacks": {},
+        "description": "Cacheable and ETagged, so a client can hold it on disk and revalidate for free.",
+        "operationId": "getBankLogo",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "image/png": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string",
+                  "x-struct": null,
+                  "x-validate": null
+                }
+              }
+            },
+            "description": "PNG"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "An institution's logo",
+        "tags": [
+          "banks"
+        ]
+      }
+    },
+    "/api/banks/{id}/sync": {
+      "post": {
+        "callbacks": {},
+        "description": "Queues the work and returns immediately. There is no completion signal - refresh the lists to\npick up whatever has landed.\n",
+        "operationId": "syncBank",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Queued"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Pull two years of history",
+        "tags": [
+          "banks"
+        ]
+      }
+    },
+    "/api/budgets": {
+      "get": {
+        "callbacks": {},
+        "description": "Spendable first, then alphabetical. Archived budgets are left out.",
+        "operationId": "listBudgets",
+        "parameters": [
+          {
+            "description": "Matches on name.",
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Budget"
+                  },
+                  "type": "array",
+                  "x-struct": null,
+                  "x-validate": null
+                }
+              }
+            },
+            "description": "Budgets"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "List budgets",
+        "tags": [
+          "budgets"
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "operationId": "createBudget",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BudgetRequest"
+              }
+            }
+          },
+          "description": "Budget",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Budget"
+                }
+              }
+            },
+            "description": "Budget"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Create a budget",
+        "tags": [
+          "budgets"
+        ]
+      }
+    },
+    "/api/budgets/summary": {
+      "get": {
+        "callbacks": {},
+        "description": "Defaults to the current month. Any date in a month selects that whole month.",
+        "operationId": "getBudgetSummary",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "month",
+            "required": false,
+            "schema": {
+              "format": "date",
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "Matches on budget name.",
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BudgetSummary"
+                }
+              }
+            },
+            "description": "BudgetSummary"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "The budgets screen for one month",
+        "tags": [
+          "budgets"
+        ]
+      }
+    },
+    "/api/budgets/{id}": {
+      "delete": {
+        "callbacks": {},
+        "description": "Budgets are archived rather than deleted, so the history they hold survives.",
+        "operationId": "archiveBudget",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Budget"
+                }
+              }
+            },
+            "description": "Budget"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Archive a budget",
+        "tags": [
+          "budgets"
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "operationId": "getBudget",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Budget"
+                }
+              }
+            },
+            "description": "Budget"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Get a budget",
+        "tags": [
+          "budgets"
+        ]
+      },
+      "patch": {
+        "callbacks": {},
+        "description": "The response carries the recalculated balance, so render it rather than the request.",
+        "operationId": "updateBudget",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BudgetRequest"
+              }
+            }
+          },
+          "description": "Budget",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Budget"
+                }
+              }
+            },
+            "description": "Budget"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Update a budget",
+        "tags": [
+          "budgets"
+        ]
+      }
+    },
+    "/api/identities": {
+      "post": {
+        "callbacks": {},
+        "description": "Attaches a second provider to the account making the request. Nothing about a person is stored\nthat would let the app match them across providers, so this is the only way two sign-in\nmethods reach one account - and it has to be done from inside it.\n",
+        "operationId": "createIdentity",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionRequest"
+              }
+            }
+          },
+          "description": "Credentials",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Identity"
+                }
+              }
+            },
+            "description": "Identity"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Add another way to sign in",
+        "tags": [
+          "session"
+        ]
+      }
+    },
+    "/api/identities/{id}": {
+      "delete": {
+        "callbacks": {},
+        "description": "Refused for the last one, which would leave an account nobody can get back into.",
+        "operationId": "deleteIdentity",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Removed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Remove a way to sign in",
+        "tags": [
+          "session"
+        ]
+      }
+    },
+    "/api/me": {
+      "get": {
+        "callbacks": {},
+        "description": "Carries the sign-in methods on the account, so the client can offer to add one.",
+        "operationId": "getCurrentUser",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            },
+            "description": "User"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "The signed-in user",
+        "tags": [
+          "session"
+        ]
+      }
+    },
+    "/api/session": {
+      "delete": {
+        "callbacks": {},
+        "description": "Revokes the token the request was made with.",
+        "operationId": "deleteSession",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Signed out"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Sign out",
+        "tags": [
+          "session"
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "description": "Exchanges an ID token from a native sign-in for an API token.",
+        "operationId": "createSession",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionRequest"
+              }
+            }
+          },
+          "description": "Credentials",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            },
+            "description": "Session"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "security": [],
+        "summary": "Sign in",
+        "tags": [
+          "session"
+        ]
+      }
+    },
+    "/api/splits": {
+      "get": {
+        "callbacks": {},
+        "description": "Alphabetical, without their lines. Archived splits are left out.",
+        "operationId": "listSplits",
+        "parameters": [
+          {
+            "description": "Matches on name.",
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Split"
+                  },
+                  "type": "array",
+                  "x-struct": null,
+                  "x-validate": null
+                }
+              }
+            },
+            "description": "Splits"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "List splits",
+        "tags": [
+          "splits"
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "operationId": "createSplit",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SplitRequest"
+              }
+            }
+          },
+          "description": "Split",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Split"
+                }
+              }
+            },
+            "description": "Split"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Create a split",
+        "tags": [
+          "splits"
+        ]
+      }
+    },
+    "/api/splits/{id}": {
+      "delete": {
+        "callbacks": {},
+        "operationId": "archiveSplit",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Split"
+                }
+              }
+            },
+            "description": "Split"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Archive a split",
+        "tags": [
+          "splits"
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "operationId": "getSplit",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Split"
+                }
+              }
+            },
+            "description": "Split"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Get a split and its lines",
+        "tags": [
+          "splits"
+        ]
+      },
+      "patch": {
+        "callbacks": {},
+        "operationId": "updateSplit",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SplitRequest"
+              }
+            }
+          },
+          "description": "Split",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Split"
+                }
+              }
+            },
+            "description": "Split"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Update a split",
+        "tags": [
+          "splits"
+        ]
+      }
+    },
+    "/api/transactions": {
+      "get": {
+        "callbacks": {},
+        "description": "Newest first. Reviewed and excluded transactions are hidden unless asked for, because the list\nis a queue of what still needs attention. A page shorter than `per_page` is the last one.\n",
+        "operationId": "listTransactions",
+        "parameters": [
+          {
+            "description": "Matches on name or note.",
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "minimum": 1,
+              "type": "integer",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "maximum": 200,
+              "minimum": 1,
+              "type": "integer",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "show_reviewed",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "x-struct": null,
+              "x-validate": null
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "show_excluded",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Transaction"
+                  },
+                  "type": "array",
+                  "x-struct": null,
+                  "x-validate": null
+                }
+              }
+            },
+            "description": "Transactions"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "List transactions",
+        "tags": [
+          "transactions"
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "description": "For money the user is recording themselves; synced activity arrives on its own.",
+        "operationId": "createTransaction",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransactionRequest"
+              }
+            }
+          },
+          "description": "Transaction",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            },
+            "description": "Transaction"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Create a transaction",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/transactions/bulk": {
+      "patch": {
+        "callbacks": {},
+        "description": "Applied one at a time rather than all or nothing, so a transaction that has since been deleted\ndoes not cost the rest their change. Check `failed` before assuming the whole set landed.\n",
+        "operationId": "updateTransactions",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkRequest"
+              }
+            }
+          },
+          "description": "Change to apply",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkResult"
+                }
+              }
+            },
+            "description": "BulkResult"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Change several transactions at once",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/transactions/bulk/delete": {
+      "post": {
+        "callbacks": {},
+        "operationId": "deleteTransactions",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkRequest"
+              }
+            }
+          },
+          "description": "Transactions to delete",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkResult"
+                }
+              }
+            },
+            "description": "BulkResult"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Delete several transactions at once",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/transactions/transfer": {
+      "post": {
+        "callbacks": {},
+        "description": "A transfer moves money between the user's own accounts rather than spending it, so the pair\nhas to be one transaction leaving an account and one arriving in another. Both sides come\nback, with their allocations cleared onto Spendable where the opposite signs cancel.\n",
+        "operationId": "createTransfer",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferRequest"
+              }
+            }
+          },
+          "description": "Transactions to link",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Transaction"
+                  },
+                  "type": "array",
+                  "x-struct": null,
+                  "x-validate": null
+                }
+              }
+            },
+            "description": "Both sides"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Link two transactions as a transfer",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/transactions/{id}": {
+      "delete": {
+        "callbacks": {},
+        "description": "Its allocations go with it.",
+        "operationId": "deleteTransaction",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "Deleted"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Delete a transaction",
+        "tags": [
+          "transactions"
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "operationId": "getTransaction",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            },
+            "description": "Transaction"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Get a transaction",
+        "tags": [
+          "transactions"
+        ]
+      },
+      "patch": {
+        "callbacks": {},
+        "description": "The response carries the allocations the server settled on. Render those.",
+        "operationId": "updateTransaction",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransactionRequest"
+              }
+            }
+          },
+          "description": "Transaction",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            },
+            "description": "Transaction"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Update a transaction",
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/api/transactions/{id}/transfer": {
+      "delete": {
+        "callbacks": {},
+        "description": "Both sides count toward budgets again. Their allocations stay where they are.",
+        "operationId": "deleteTransfer",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-struct": null,
+              "x-validate": null
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            },
+            "description": "Transaction"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            },
+            "description": "Errors"
+          }
+        },
+        "summary": "Unlink a transfer",
+        "tags": [
+          "transactions"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "bearer": []
+    }
+  ],
+  "servers": [
+    {
+      "url": "https://spendable.money",
+      "variables": {}
+    }
+  ],
+  "tags": []
+}

--- a/shared/budget_cards.json
+++ b/shared/budget_cards.json
@@ -1,0 +1,168 @@
+{
+  "_comment": [
+    "What a budget reads as on the budgets screen, and how money is written.",
+    "Both clients compute this locally, so this table is the only thing keeping them honest.",
+    "Elixir: lib/spendable_web/utils/budget_card_test.exs. Dart: mobile/test/budgets/budget_card_test.dart."
+  ],
+  "cards": [
+    {
+      "name": "a past month is a record of what was spent",
+      "current_month": false,
+      "budget": { "type": "envelope", "balance": "50.00", "budgeted_amount": "200.00" },
+      "spent": "45.50",
+      "card": { "amount": "45.50", "label": "SPENT", "percent": null, "bar": null, "footer": null }
+    },
+    {
+      "name": "a tracking budget only ever reports the spend",
+      "current_month": true,
+      "budget": { "type": "tracking", "balance": "0.00", "budgeted_amount": null },
+      "spent": "12.34",
+      "card": {
+        "amount": "12.34",
+        "label": "SPENT",
+        "percent": null,
+        "bar": null,
+        "footer": "No limit set"
+      }
+    },
+    {
+      "name": "an envelope with no amount budgeted has nothing to be a fraction of",
+      "current_month": true,
+      "budget": { "type": "envelope", "balance": "80.00", "budgeted_amount": null },
+      "spent": "10.00",
+      "card": {
+        "amount": "80.00",
+        "label": "LEFT",
+        "percent": null,
+        "bar": null,
+        "footer": "No limit set"
+      }
+    },
+    {
+      "name": "an envelope under budget",
+      "current_month": true,
+      "budget": { "type": "envelope", "balance": "50.00", "budgeted_amount": "200.00" },
+      "spent": "150.00",
+      "card": {
+        "amount": "50.00",
+        "label": "LEFT",
+        "percent": 75.0,
+        "bar": "under",
+        "footer": "$150.00 of $200.00 spent"
+      }
+    },
+    {
+      "name": "spending exactly the budget is not over it",
+      "current_month": true,
+      "budget": { "type": "envelope", "balance": "0.00", "budgeted_amount": "200.00" },
+      "spent": "200.00",
+      "card": {
+        "amount": "0.00",
+        "label": "LEFT",
+        "percent": 100.0,
+        "bar": "under",
+        "footer": "$200.00 of $200.00 spent"
+      }
+    },
+    {
+      "name": "an envelope over budget keeps the bar full",
+      "current_month": true,
+      "budget": { "type": "envelope", "balance": "-25.00", "budgeted_amount": "200.00" },
+      "spent": "225.00",
+      "card": {
+        "amount": "-25.00",
+        "label": "LEFT",
+        "percent": 100.0,
+        "bar": "over",
+        "footer": "$225.00 of $200.00 spent"
+      }
+    },
+    {
+      "name": "a budget of zero divides by nothing and is over the moment anything is spent",
+      "current_month": true,
+      "budget": { "type": "envelope", "balance": "10.00", "budgeted_amount": "0.00" },
+      "spent": "5.00",
+      "card": {
+        "amount": "10.00",
+        "label": "LEFT",
+        "percent": 0.0,
+        "bar": "over",
+        "footer": "$5.00 of $0.00 spent"
+      }
+    },
+    {
+      "name": "a percentage that does not divide evenly rounds to one place",
+      "current_month": true,
+      "budget": { "type": "envelope", "balance": "100.00", "budgeted_amount": "300.00" },
+      "spent": "200.00",
+      "card": {
+        "amount": "100.00",
+        "label": "LEFT",
+        "percent": 66.7,
+        "bar": "under",
+        "footer": "$200.00 of $300.00 spent"
+      }
+    },
+    {
+      "name": "thousands are grouped on both sides of the footer",
+      "current_month": true,
+      "budget": { "type": "envelope", "balance": "-1500.75", "budgeted_amount": "1000.00" },
+      "spent": "2500.75",
+      "card": {
+        "amount": "-1500.75",
+        "label": "LEFT",
+        "percent": 100.0,
+        "bar": "over",
+        "footer": "$2,500.75 of $1,000.00 spent"
+      }
+    },
+    {
+      "name": "a goal with no target has nothing to go",
+      "current_month": true,
+      "budget": { "type": "goal", "balance": "500.00", "budgeted_amount": null },
+      "spent": "0.00",
+      "card": {
+        "amount": "500.00",
+        "label": "SAVED",
+        "percent": null,
+        "bar": null,
+        "footer": "No goal set"
+      }
+    },
+    {
+      "name": "a goal counts down to the target rather than up from zero",
+      "current_month": true,
+      "budget": { "type": "goal", "balance": "250.00", "budgeted_amount": "1000.00" },
+      "spent": "0.00",
+      "card": {
+        "amount": "750.00",
+        "label": "TO GO",
+        "percent": 25.0,
+        "bar": "goal",
+        "footer": "$250.00 of $1,000.00 saved"
+      }
+    },
+    {
+      "name": "saving past the goal goes negative and the bar stops at full",
+      "current_month": true,
+      "budget": { "type": "goal", "balance": "1200.00", "budgeted_amount": "1000.00" },
+      "spent": "0.00",
+      "card": {
+        "amount": "-200.00",
+        "label": "TO GO",
+        "percent": 100.0,
+        "bar": "goal",
+        "footer": "$1,200.00 of $1,000.00 saved"
+      }
+    }
+  ],
+  "currency": [
+    { "amount": null, "formatted": "$0.00" },
+    { "amount": "0", "formatted": "$0.00" },
+    { "amount": "7.5", "formatted": "$7.50" },
+    { "amount": "-0.005", "formatted": "-$0.01" },
+    { "amount": "999.999", "formatted": "$1,000.00" },
+    { "amount": "1000", "formatted": "$1,000.00" },
+    { "amount": "-1234567.891", "formatted": "-$1,234,567.89" }
+  ]
+}


### PR DESCRIPTION
Stacked on #768, which is stacked on #767.

Cards, month picker, totals and the edit sheet, against `GET /api/budgets/summary`.

**The interesting part is `build_card`.** It was private in the LiveView and had to be reimplemented in Dart — six branches deciding what number a budget shows, what it is called, and how full the bar is. That is the highest silent-divergence risk in the app, so:

- extracted to `SpendableWeb.Utils.BudgetCard`, mirrored in `BudgetCard.build`
- [`shared/budget_cards.json`](shared/budget_cards.json) drives a table test in **both** languages — 19 cases covering every branch, percent rounding and clamping, division by a zero budget, and currency formatting including thousands grouping and half-up rounding
- colours stay with each client: the util answers *which* of the three bars a card draws, not what it looks like

`budgets_test.exs` passes unedited, which is the proof the extraction was behaviour-preserving.

**Saving re-reads the whole summary** rather than patching the row — changing one budget's allocation moves what is left on Spendable, so the returned row is not the only one that changed. That is the one documented exception to the mutate-then-render-the-response rule.

The synthetic Credit Cards card is composed client-side from `credit_card_balance`, current month only, and is not editable.

420 Elixir tests at 100% coverage; 47 Dart tests, analyze and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)