### PR TITLE
Transactions screen

### DIFF
--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'auth/auth_controller.dart';
 import 'auth/sign_in_screen.dart';
-import 'budgets/budgets_screen.dart';
+import 'shell.dart';
 import 'theme.dart';
 
 class SpendableApp extends ConsumerWidget {
@@ -20,7 +20,7 @@ class SpendableApp extends ConsumerWidget {
       // Null only while the first Keychain read is in flight. Signing in and out never puts this
       // back into loading, so the screen cannot fall back to the splash mid-flow.
       home: switch (auth.value) {
-        true => const BudgetsScreen(),
+        true => const Shell(),
         false => const SignInScreen(),
         null => const _Splash(),
       },

--- a/mobile/lib/shell.dart
+++ b/mobile/lib/shell.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import 'budgets/budgets_screen.dart';
+import 'transactions/transactions_screen.dart';
+
+/// IndexedStack rather than a swapped child, so switching tabs keeps each screen's scroll
+/// position and its loaded pages.
+class Shell extends StatefulWidget {
+  const Shell({super.key});
+
+  @override
+  State<Shell> createState() => _ShellState();
+}
+
+class _ShellState extends State<Shell> {
+  var _tab = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(index: _tab, children: const [BudgetsScreen(), TransactionsScreen()]),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _tab,
+        onDestinationSelected: (index) => setState(() => _tab = index),
+        destinations: const [
+          NavigationDestination(
+            key: Key('tab-budgets'),
+            icon: Icon(Icons.pie_chart_outline),
+            selectedIcon: Icon(Icons.pie_chart),
+            label: 'Budgets',
+          ),
+          NavigationDestination(
+            key: Key('tab-transactions'),
+            icon: Icon(Icons.receipt_long_outlined),
+            selectedIcon: Icon(Icons.receipt_long),
+            label: 'Transactions',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/transactions/transaction_detail.dart
+++ b/mobile/lib/transactions/transaction_detail.dart
@@ -1,0 +1,311 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:decimal/decimal.dart';
+import 'package:flutter/material.dart' hide Split;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spendable_api/spendable_api.dart';
+
+import '../api/api_error.dart';
+import '../theme.dart';
+import 'transactions_controller.dart';
+import 'transactions_providers.dart';
+
+/// One allocation being edited. Kept apart from the wire type because a line the user is still
+/// typing has no valid amount yet.
+class _Line {
+  _Line({this.id, required this.budgetId, required String amount})
+    : amount = TextEditingController(text: amount);
+
+  final String? id;
+  final TextEditingController amount;
+
+  String? budgetId;
+}
+
+class TransactionDetail extends ConsumerStatefulWidget {
+  const TransactionDetail({super.key, required this.transaction});
+
+  final Transaction transaction;
+
+  @override
+  ConsumerState<TransactionDetail> createState() => _TransactionDetailState();
+}
+
+class _TransactionDetailState extends ConsumerState<TransactionDetail> {
+  late final _name = TextEditingController(text: widget.transaction.name);
+  late final _amount = TextEditingController(text: widget.transaction.amount);
+  late final _note = TextEditingController(text: widget.transaction.note ?? '');
+
+  late var _date = widget.transaction.date;
+  late var _reviewed = widget.transaction.reviewed;
+  late var _excluded = widget.transaction.excluded;
+
+  late var _lines = [
+    for (final allocation in widget.transaction.budgetAllocations)
+      _Line(id: allocation.id, budgetId: allocation.budgetId, amount: allocation.amount),
+  ];
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _amount.dispose();
+    _note.dispose();
+    for (final line in _lines) {
+      line.amount.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(transactionsControllerProvider);
+    final errors = state.error is ApiError
+        ? (state.error! as ApiError).fieldErrors
+        : const <String, String>{};
+    final budgets = ref.watch(budgetOptionsProvider).value ?? const <Budget>[];
+
+    // Watched rather than read in the picker, so the splits are already loaded when it opens.
+    final splits = ref.watch(splitOptionsProvider).value ?? const <Split>[];
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 20,
+        right: 20,
+        top: 20,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 20,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Save stays put: the fields below it scroll, and on a phone the button would
+          // otherwise sit past the fold.
+          Row(
+            children: [
+              Expanded(child: Text('Edit transaction', style: Theme.of(context).textTheme.titleLarge)),
+              TextButton(
+                key: const Key('transaction-save'),
+                onPressed: state.isLoading ? null : _save,
+                child: const Text('Save'),
+              ),
+            ],
+          ),
+          Flexible(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const SizedBox(height: 8),
+                  TextField(
+                    key: const Key('transaction-name'),
+                    controller: _name,
+                    decoration: InputDecoration(labelText: 'Name', errorText: errors['/name']),
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    key: const Key('transaction-amount'),
+                    controller: _amount,
+                    keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: true),
+                    onChanged: (_) => setState(() {}),
+                    decoration: InputDecoration(labelText: 'Amount', errorText: errors['/amount']),
+                  ),
+                  const SizedBox(height: 8),
+                  ListTile(
+                    key: const Key('transaction-date'),
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Date'),
+                    trailing: Text('$_date'),
+                    onTap: _pickDate,
+                  ),
+                  const Divider(height: 24),
+                  _allocations(budgets, splits, errors),
+                  const SizedBox(height: 16),
+                  TextField(
+                    key: const Key('transaction-note'),
+                    controller: _note,
+                    maxLines: 3,
+                    decoration: const InputDecoration(labelText: 'Note'),
+                  ),
+                  if (widget.transaction.transferId != null) ...[
+                    const SizedBox(height: 8),
+                    ListTile(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('Part of a transfer'),
+                      trailing: TextButton(
+                        key: const Key('remove-transfer'),
+                        onPressed: state.isLoading ? null : _removeTransfer,
+                        child: const Text('Remove'),
+                      ),
+                    ),
+                  ],
+                  Row(
+                    children: [
+                      Expanded(
+                        child: CheckboxListTile(
+                          key: const Key('transaction-reviewed'),
+                          contentPadding: EdgeInsets.zero,
+                          title: const Text('Reviewed'),
+                          value: _reviewed,
+                          onChanged: (value) => setState(() => _reviewed = value ?? false),
+                        ),
+                      ),
+                      Expanded(
+                        child: CheckboxListTile(
+                          key: const Key('transaction-excluded'),
+                          contentPadding: EdgeInsets.zero,
+                          title: const Text('Excluded'),
+                          value: _excluded,
+                          onChanged: (value) => setState(() => _excluded = value ?? false),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _allocations(List<Budget> budgets, List<Split> splits, Map<String, String> errors) {
+    // A transaction with one allocation splits nothing, so that line carries the whole amount and
+    // only the budget is worth asking about.
+    final single = _lines.length <= 1;
+    final negative = (Decimal.tryParse(_amount.text.trim()) ?? Decimal.zero).sign < 0;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(negative ? 'Spend from' : 'Add to', style: const TextStyle(color: SpendableColors.muted)),
+        const SizedBox(height: 8),
+        for (final (index, line) in _lines.indexed)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  flex: 3,
+                  child: DropdownButtonFormField<String>(
+                    key: Key('allocation-budget-$index'),
+                    initialValue: line.budgetId,
+                    isExpanded: true,
+                    items: [
+                      for (final budget in budgets)
+                        DropdownMenuItem(
+                          value: budget.id,
+                          child: Text(budget.name, overflow: TextOverflow.ellipsis),
+                        ),
+                    ],
+                    onChanged: (value) => setState(() => line.budgetId = value),
+                  ),
+                ),
+                if (!single) ...[
+                  const SizedBox(width: 8),
+                  Expanded(
+                    flex: 2,
+                    child: TextField(
+                      key: Key('allocation-amount-$index'),
+                      controller: line.amount,
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: true),
+                      decoration: InputDecoration(errorText: errors['/budget_allocations/$index/amount']),
+                    ),
+                  ),
+                  IconButton(
+                    key: Key('allocation-remove-$index'),
+                    icon: const Icon(Icons.remove_circle_outline),
+                    onPressed: () => setState(() => _lines = [..._lines]..removeAt(index)),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            TextButton(key: const Key('add-line'), onPressed: _addLine, child: const Text('Add line')),
+            TextButton(
+              key: const Key('apply-split'),
+              onPressed: () => _pickSplit(splits),
+              child: const Text('Apply split'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  void _addLine() => setState(() => _lines = [..._lines, _Line(budgetId: null, amount: '')]);
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _date.toDateTime(),
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+
+    if (picked != null) setState(() => _date = Date(picked.year, picked.month, picked.day));
+  }
+
+  /// Applying a split only rewrites the lines here; the server sees them on save like any others.
+  Future<void> _pickSplit(List<Split> splits) async {
+    final chosen = await showModalBottomSheet<Split>(
+      context: context,
+      builder: (_) => ListView(
+        children: [
+          for (final split in splits)
+            ListTile(
+              key: Key('split-${split.id}'),
+              title: Text(split.name),
+              onTap: () => Navigator.of(context).pop(split),
+            ),
+        ],
+      ),
+    );
+
+    if (chosen == null) return;
+
+    setState(() {
+      _lines = [for (final line in chosen.splitLines) _Line(budgetId: line.budgetId, amount: line.amount)];
+    });
+  }
+
+  Future<void> _save() async {
+    final single = _lines.length <= 1;
+
+    final allocations = [
+      for (final line in _lines)
+        BudgetAllocationRequest(
+          (builder) => builder
+            ..id = line.id
+            ..budgetId = line.budgetId
+            ..amount = single ? _amount.text.trim() : line.amount.text.trim(),
+        ),
+    ];
+
+    final request = TransactionRequest(
+      (builder) => builder
+        ..name = _name.text
+        ..amount = _amount.text.trim()
+        ..date = _date
+        ..note = _note.text.isEmpty ? null : _note.text
+        ..reviewed = _reviewed
+        ..excluded = _excluded
+        ..budgetAllocations = ListBuilder(allocations),
+    );
+
+    final saved = await ref.read(transactionsControllerProvider.notifier).update(widget.transaction, request);
+
+    if (saved && mounted) Navigator.of(context).pop();
+  }
+
+  Future<void> _removeTransfer() async {
+    final removed = await ref
+        .read(transactionsControllerProvider.notifier)
+        .removeTransfer(widget.transaction);
+
+    if (removed && mounted) Navigator.of(context).pop();
+  }
+}

--- a/mobile/lib/transactions/transactions_controller.dart
+++ b/mobile/lib/transactions/transactions_controller.dart
@@ -1,0 +1,104 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:spendable_api/spendable_api.dart';
+
+import '../api/api_client.dart';
+import '../api/api_error.dart';
+import 'transactions_providers.dart';
+
+part 'transactions_controller.g.dart';
+
+/// Writing transactions. Every write renders the transaction that came back rather than what was
+/// sent: the server re-runs the allocation split on each save, so the response is the only
+/// account of what a transaction now looks like.
+@riverpod
+class TransactionsController extends _$TransactionsController {
+  @override
+  AsyncValue<void> build() => const AsyncData(null);
+
+  Future<bool> update(Transaction transaction, TransactionRequest request) => _write(() async {
+    final response = await _api
+        .updateTransaction(id: transaction.id, transactionRequest: request)
+        .orApiError();
+
+    ref.read(transactionsProvider.notifier).replace(response.data!);
+  });
+
+  Future<bool> toggleReviewed(Transaction transaction) =>
+      update(transaction, TransactionRequest((builder) => builder.reviewed = !transaction.reviewed));
+
+  /// A transaction with one allocation splits nothing, so the row can move the whole amount to a
+  /// different budget in one go.
+  Future<bool> spendFrom(Transaction transaction, String budgetId) => update(
+    transaction,
+    TransactionRequest(
+      (builder) => builder.budgetAllocations = ListBuilder([
+        BudgetAllocationRequest(
+          (line) => line
+            ..amount = transaction.amount
+            ..budgetId = budgetId,
+        ),
+      ]),
+    ),
+  );
+
+  Future<bool> bulk({required Set<String> ids, bool? reviewed, bool? excluded, String? budgetId}) =>
+      _write(() async {
+        final request = BulkRequest(
+          (builder) => builder
+            ..transactionIds = ListBuilder(ids)
+            ..reviewed = reviewed
+            ..excluded = excluded
+            ..budgetId = budgetId,
+        );
+
+        final response = await _api.updateTransactions(bulkRequest: request).orApiError();
+
+        _applyBulk(response.data!);
+      });
+
+  Future<bool> deleteAll(Set<String> ids) => _write(() async {
+    final request = BulkRequest((builder) => builder.transactionIds = ListBuilder(ids));
+    final response = await _api.deleteTransactions(bulkRequest: request).orApiError();
+
+    ref.read(transactionsProvider.notifier).remove(ids.difference(_failedIds(response.data!)));
+    ref.read(selectionProvider.notifier).clear();
+  });
+
+  /// Both sides of a transfer come back, because pairing changes them both.
+  Future<bool> markAsTransfer(Set<String> ids) => _write(() async {
+    final request = TransferRequest((builder) => builder.transactionIds = ListBuilder(ids));
+    final response = await _api.createTransfer(transferRequest: request).orApiError();
+
+    for (final transaction in response.data!) {
+      ref.read(transactionsProvider.notifier).replace(transaction);
+    }
+
+    ref.read(selectionProvider.notifier).clear();
+  });
+
+  Future<bool> removeTransfer(Transaction transaction) => _write(() async {
+    final response = await _api.deleteTransfer(id: transaction.id).orApiError();
+
+    ref.read(transactionsProvider.notifier).replace(response.data!);
+  });
+
+  TransactionsApi get _api => ref.read(apiProvider).getTransactionsApi();
+
+  void _applyBulk(BulkResult result) {
+    for (final transaction in result.transactions) {
+      ref.read(transactionsProvider.notifier).replace(transaction);
+    }
+
+    ref.read(selectionProvider.notifier).clear();
+  }
+
+  Set<String> _failedIds(BulkResult result) => result.failed.map((failure) => failure.id).toSet();
+
+  Future<bool> _write(Future<void> Function() write) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(write);
+
+    return !state.hasError;
+  }
+}

--- a/mobile/lib/transactions/transactions_controller.g.dart
+++ b/mobile/lib/transactions/transactions_controller.g.dart
@@ -1,0 +1,72 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'transactions_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Writing transactions. Every write renders the transaction that came back rather than what was
+/// sent: the server re-runs the allocation split on each save, so the response is the only
+/// account of what a transaction now looks like.
+
+@ProviderFor(TransactionsController)
+final transactionsControllerProvider = TransactionsControllerProvider._();
+
+/// Writing transactions. Every write renders the transaction that came back rather than what was
+/// sent: the server re-runs the allocation split on each save, so the response is the only
+/// account of what a transaction now looks like.
+final class TransactionsControllerProvider
+    extends $NotifierProvider<TransactionsController, AsyncValue<void>> {
+  /// Writing transactions. Every write renders the transaction that came back rather than what was
+  /// sent: the server re-runs the allocation split on each save, so the response is the only
+  /// account of what a transaction now looks like.
+  TransactionsControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'transactionsControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$transactionsControllerHash();
+
+  @$internal
+  @override
+  TransactionsController create() => TransactionsController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AsyncValue<void> value) {
+    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<AsyncValue<void>>(value));
+  }
+}
+
+String _$transactionsControllerHash() => r'684e2fcfec358b2f01f0a8cc8dc555cd96fa1a24';
+
+/// Writing transactions. Every write renders the transaction that came back rather than what was
+/// sent: the server re-runs the allocation split on each save, so the response is the only
+/// account of what a transaction now looks like.
+
+abstract class _$TransactionsController extends $Notifier<AsyncValue<void>> {
+  AsyncValue<void> build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<void>, AsyncValue<void>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<void>, AsyncValue<void>>,
+              AsyncValue<void>,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/mobile/lib/transactions/transactions_providers.dart
+++ b/mobile/lib/transactions/transactions_providers.dart
@@ -1,0 +1,154 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:spendable_api/spendable_api.dart';
+
+import '../api/api_client.dart';
+import '../api/api_error.dart';
+
+part 'transactions_providers.g.dart';
+
+const _perPage = 50;
+
+/// The list is a queue of what still needs attention, so excluded rows are hidden by default.
+/// Reviewed ones are shown, which the API does not assume - it has to be asked for.
+class TransactionFilters {
+  const TransactionFilters({this.search, this.showReviewed = true, this.showExcluded = false});
+
+  final String? search;
+  final bool showReviewed;
+  final bool showExcluded;
+
+  TransactionFilters copyWith({String? search, bool? showReviewed, bool? showExcluded}) => TransactionFilters(
+    search: search ?? this.search,
+    showReviewed: showReviewed ?? this.showReviewed,
+    showExcluded: showExcluded ?? this.showExcluded,
+  );
+
+  /// Mirrors `visible?/2`: a row leaves the list when a change no longer matches, which is what
+  /// makes reviewing clear the queue.
+  bool matches(Transaction transaction) =>
+      (showReviewed || !transaction.reviewed) && (showExcluded || !transaction.excluded);
+}
+
+@riverpod
+class Filters extends _$Filters {
+  @override
+  TransactionFilters build() => const TransactionFilters();
+
+  void search(String term) => state = state.copyWith(search: term.isEmpty ? null : term);
+
+  void toggleReviewed() => state = state.copyWith(showReviewed: !state.showReviewed);
+
+  void toggleExcluded() => state = state.copyWith(showExcluded: !state.showExcluded);
+}
+
+class TransactionPage {
+  const TransactionPage({required this.transactions, required this.atEnd});
+
+  final List<Transaction> transactions;
+  final bool atEnd;
+}
+
+/// Pages append rather than replace. A page shorter than what was asked for is the last one.
+@riverpod
+class Transactions extends _$Transactions {
+  var _page = 1;
+
+  /// Watching the filters is what refetches when one changes, and is also what keeps them from
+  /// being disposed while the sheet that edits them is closed.
+  @override
+  Future<TransactionPage> build() async {
+    final filters = ref.watch(filtersProvider);
+
+    _page = 1;
+
+    return TransactionPage(transactions: await _fetch(1, filters), atEnd: false);
+  }
+
+  Future<void> loadMore() async {
+    final current = state.value;
+
+    if (current == null || current.atEnd || state.isLoading) return;
+
+    final next = await _fetch(_page + 1, ref.read(filtersProvider));
+
+    _page += 1;
+
+    state = AsyncData(
+      TransactionPage(transactions: [...current.transactions, ...next], atEnd: next.length < _perPage),
+    );
+  }
+
+  /// Replaces one row with what the server settled on, or drops it when it no longer belongs in
+  /// the list. Rewriting the row keeps the reader's place; refetching would send them to the top.
+  void replace(Transaction transaction) {
+    final current = state.value;
+
+    if (current == null) return;
+
+    final matches = ref.read(filtersProvider).matches(transaction);
+
+    state = AsyncData(
+      TransactionPage(
+        transactions: [
+          for (final existing in current.transactions)
+            if (existing.id != transaction.id) existing else if (matches) transaction,
+        ],
+        atEnd: current.atEnd,
+      ),
+    );
+  }
+
+  void remove(Iterable<String> ids) {
+    final current = state.value;
+
+    if (current == null) return;
+
+    state = AsyncData(
+      TransactionPage(
+        transactions: current.transactions.where((each) => !ids.contains(each.id)).toList(),
+        atEnd: current.atEnd,
+      ),
+    );
+  }
+
+  Future<List<Transaction>> _fetch(int page, TransactionFilters filters) async {
+    final response = await ref
+        .read(apiProvider)
+        .getTransactionsApi()
+        .listTransactions(
+          search: filters.search,
+          page: page,
+          perPage: _perPage,
+          showReviewed: filters.showReviewed,
+          showExcluded: filters.showExcluded,
+        )
+        .orApiError();
+
+    return response.data!.toList();
+  }
+}
+
+/// The budget and split pickers the rows and the detail sheet offer.
+@riverpod
+Future<List<Budget>> budgetOptions(Ref ref) async {
+  final response = await ref.watch(apiProvider).getBudgetsApi().listBudgets().orApiError();
+
+  return response.data!.toList();
+}
+
+@riverpod
+Future<List<Split>> splitOptions(Ref ref) async {
+  final response = await ref.watch(apiProvider).getSplitsApi().listSplits().orApiError();
+
+  return response.data!.toList();
+}
+
+@riverpod
+class Selection extends _$Selection {
+  @override
+  Set<String> build() => const {};
+
+  void toggle(String id) => state = state.contains(id) ? ({...state}..remove(id)) : {...state, id};
+
+  void clear() => state = const {};
+}

--- a/mobile/lib/transactions/transactions_providers.g.dart
+++ b/mobile/lib/transactions/transactions_providers.g.dart
@@ -1,0 +1,221 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'transactions_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(Filters)
+final filtersProvider = FiltersProvider._();
+
+final class FiltersProvider extends $NotifierProvider<Filters, TransactionFilters> {
+  FiltersProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'filtersProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$filtersHash();
+
+  @$internal
+  @override
+  Filters create() => Filters();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(TransactionFilters value) {
+    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<TransactionFilters>(value));
+  }
+}
+
+String _$filtersHash() => r'16133d52d4b6a5afc6c00a3be3d3f118f47646b8';
+
+abstract class _$Filters extends $Notifier<TransactionFilters> {
+  TransactionFilters build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<TransactionFilters, TransactionFilters>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<TransactionFilters, TransactionFilters>,
+              TransactionFilters,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}
+
+/// Pages append rather than replace. A page shorter than what was asked for is the last one.
+
+@ProviderFor(Transactions)
+final transactionsProvider = TransactionsProvider._();
+
+/// Pages append rather than replace. A page shorter than what was asked for is the last one.
+final class TransactionsProvider extends $AsyncNotifierProvider<Transactions, TransactionPage> {
+  /// Pages append rather than replace. A page shorter than what was asked for is the last one.
+  TransactionsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'transactionsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$transactionsHash();
+
+  @$internal
+  @override
+  Transactions create() => Transactions();
+}
+
+String _$transactionsHash() => r'764fa574c14011b86d9f7a4029be58b7c59a3b58';
+
+/// Pages append rather than replace. A page shorter than what was asked for is the last one.
+
+abstract class _$Transactions extends $AsyncNotifier<TransactionPage> {
+  FutureOr<TransactionPage> build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AsyncValue<TransactionPage>, TransactionPage>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<TransactionPage>, TransactionPage>,
+              AsyncValue<TransactionPage>,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}
+
+/// The budget and split pickers the rows and the detail sheet offer.
+
+@ProviderFor(budgetOptions)
+final budgetOptionsProvider = BudgetOptionsProvider._();
+
+/// The budget and split pickers the rows and the detail sheet offer.
+
+final class BudgetOptionsProvider
+    extends $FunctionalProvider<AsyncValue<List<Budget>>, List<Budget>, FutureOr<List<Budget>>>
+    with $FutureModifier<List<Budget>>, $FutureProvider<List<Budget>> {
+  /// The budget and split pickers the rows and the detail sheet offer.
+  BudgetOptionsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'budgetOptionsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$budgetOptionsHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<Budget>> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<Budget>> create(Ref ref) {
+    return budgetOptions(ref);
+  }
+}
+
+String _$budgetOptionsHash() => r'064a5f67d9ec443f9f5436be2ef8d35721a31d60';
+
+@ProviderFor(splitOptions)
+final splitOptionsProvider = SplitOptionsProvider._();
+
+final class SplitOptionsProvider
+    extends $FunctionalProvider<AsyncValue<List<Split>>, List<Split>, FutureOr<List<Split>>>
+    with $FutureModifier<List<Split>>, $FutureProvider<List<Split>> {
+  SplitOptionsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'splitOptionsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$splitOptionsHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<Split>> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<Split>> create(Ref ref) {
+    return splitOptions(ref);
+  }
+}
+
+String _$splitOptionsHash() => r'17a7b7825cc7c29628b050532b206c645e1bad74';
+
+@ProviderFor(Selection)
+final selectionProvider = SelectionProvider._();
+
+final class SelectionProvider extends $NotifierProvider<Selection, Set<String>> {
+  SelectionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'selectionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$selectionHash();
+
+  @$internal
+  @override
+  Selection create() => Selection();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Set<String> value) {
+    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<Set<String>>(value));
+  }
+}
+
+String _$selectionHash() => r'ac4009fb7f720fec495e12ce689e9a655c332d23';
+
+abstract class _$Selection extends $Notifier<Set<String>> {
+  Set<String> build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<Set<String>, Set<String>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<AnyNotifier<Set<String>, Set<String>>, Set<String>, Object?, Object?>;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/mobile/lib/transactions/transactions_screen.dart
+++ b/mobile/lib/transactions/transactions_screen.dart
@@ -1,0 +1,304 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:spendable_api/spendable_api.dart';
+
+import '../api/api_error.dart';
+import '../money.dart';
+import '../theme.dart';
+import 'transaction_detail.dart';
+import 'transactions_controller.dart';
+import 'transactions_providers.dart';
+
+const _monthAbbreviations = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+String shortDate(Date date) => '${_monthAbbreviations[date.month - 1]} ${date.day}, ${date.year}';
+
+class TransactionsScreen extends ConsumerWidget {
+  const TransactionsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final page = ref.watch(transactionsProvider);
+    final selection = ref.watch(selectionProvider);
+
+    ref.listen(transactionsControllerProvider, (_, next) {
+      // A validation error is already against the field it belongs to, so it needs no banner.
+      if (next case AsyncError(:final error) when error is! ApiError || error.fieldErrors.isEmpty) {
+        ScaffoldMessenger.of(context)
+          ..clearSnackBars()
+          ..showSnackBar(SnackBar(content: Text('$error')));
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Transactions'),
+        actions: [
+          IconButton(
+            key: const Key('open-filters'),
+            icon: const Icon(Icons.filter_list),
+            onPressed: () => showModalBottomSheet<void>(context: context, builder: (_) => const _Filters()),
+          ),
+        ],
+      ),
+      bottomNavigationBar: selection.isEmpty ? null : _BulkActions(selection: selection),
+      body: RefreshIndicator(
+        onRefresh: () async => ref.invalidate(transactionsProvider),
+        child: switch (page) {
+          AsyncData(value: final page) => _List(page: page, selection: selection),
+          AsyncError(:final error) => _Message('$error'),
+          _ => const Center(child: CircularProgressIndicator()),
+        },
+      ),
+    );
+  }
+}
+
+class _List extends ConsumerWidget {
+  const _List({required this.page, required this.selection});
+
+  final TransactionPage page;
+  final Set<String> selection;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (page.transactions.isEmpty) return const _Message('Nothing to review.');
+
+    return NotificationListener<ScrollEndNotification>(
+      onNotification: (notification) {
+        final metrics = notification.metrics;
+
+        if (metrics.pixels >= metrics.maxScrollExtent - 400) {
+          ref.read(transactionsProvider.notifier).loadMore();
+        }
+
+        return false;
+      },
+      child: ListView.separated(
+        itemCount: page.transactions.length,
+        separatorBuilder: (_, _) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final transaction = page.transactions[index];
+
+          return _Row(transaction: transaction, selected: selection.contains(transaction.id));
+        },
+      ),
+    );
+  }
+}
+
+class _Row extends ConsumerWidget {
+  const _Row({required this.transaction, required this.selected});
+
+  final Transaction transaction;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.read(transactionsControllerProvider.notifier);
+    final source = transaction.source_;
+
+    // An excluded row and one already paired as a transfer are both out of the running.
+    final dimmed = transaction.excluded || transaction.transferId != null;
+
+    return Opacity(
+      opacity: dimmed ? 0.4 : 1,
+      child: ListTile(
+        key: Key('transaction-${transaction.id}'),
+        onTap: () => showModalBottomSheet<void>(
+          context: context,
+          isScrollControlled: true,
+          builder: (_) => TransactionDetail(transaction: transaction),
+        ),
+        onLongPress: () => ref.read(selectionProvider.notifier).toggle(transaction.id),
+        leading: Checkbox(
+          key: Key('select-${transaction.id}'),
+          value: selected,
+          onChanged: (_) => ref.read(selectionProvider.notifier).toggle(transaction.id),
+        ),
+        title: Text(transaction.name, overflow: TextOverflow.ellipsis),
+        subtitle: Text(
+          [
+            shortDate(transaction.date),
+            if (source != null) '${source.accountName} ••••${source.accountNumber ?? ''}',
+            if (transaction.transferId != null) 'Transfer',
+          ].join('  ·  '),
+          style: const TextStyle(color: SpendableColors.muted, fontSize: 12),
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              formatCurrency(money(transaction.amount)),
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+            IconButton(
+              key: Key('reviewed-${transaction.id}'),
+              tooltip: transaction.reviewed ? 'Mark unreviewed' : 'Mark reviewed',
+              icon: Icon(
+                transaction.reviewed ? Icons.check_circle : Icons.circle_outlined,
+                color: transaction.reviewed ? SpendableColors.positive : SpendableColors.muted,
+              ),
+              onPressed: () => controller.toggleReviewed(transaction),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Filters extends ConsumerWidget {
+  const _Filters();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filters = ref.watch(filtersProvider);
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: TextField(
+              key: const Key('transaction-search'),
+              decoration: const InputDecoration(labelText: 'Search name or note'),
+              onSubmitted: ref.read(filtersProvider.notifier).search,
+            ),
+          ),
+          SwitchListTile(
+            key: const Key('filter-reviewed'),
+            title: const Text('Show reviewed transactions'),
+            value: filters.showReviewed,
+            onChanged: (_) => ref.read(filtersProvider.notifier).toggleReviewed(),
+          ),
+          SwitchListTile(
+            key: const Key('filter-excluded'),
+            title: const Text('Show excluded transactions'),
+            value: filters.showExcluded,
+            onChanged: (_) => ref.read(filtersProvider.notifier).toggleExcluded(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BulkActions extends ConsumerWidget {
+  const _BulkActions({required this.selection});
+
+  final Set<String> selection;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.read(transactionsControllerProvider.notifier);
+
+    return BottomAppBar(
+      color: SpendableColors.surface,
+      child: Row(
+        children: [
+          IconButton(
+            key: const Key('bulk-clear'),
+            icon: const Icon(Icons.close),
+            onPressed: () => ref.read(selectionProvider.notifier).clear(),
+          ),
+          Text('${selection.length}'),
+          // The actions do not fit across a phone, and one of them appearing only for a pair
+          // means the width changes as the selection does.
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              reverse: true,
+              child: Row(
+                children: [
+                  TextButton(
+                    key: const Key('bulk-review'),
+                    onPressed: () => controller.bulk(ids: selection, reviewed: true),
+                    child: const Text('Review'),
+                  ),
+                  TextButton(
+                    key: const Key('bulk-exclude'),
+                    onPressed: () => controller.bulk(ids: selection, excluded: true),
+                    child: const Text('Exclude'),
+                  ),
+                  TextButton(
+                    key: const Key('bulk-spend-from'),
+                    onPressed: () => _pickBudget(context, ref),
+                    child: const Text('Spend from'),
+                  ),
+                  // A transfer is one transaction leaving an account and one arriving in another.
+                  if (selection.length == 2)
+                    TextButton(
+                      key: const Key('bulk-transfer'),
+                      onPressed: () => controller.markAsTransfer(selection),
+                      child: const Text('Transfer'),
+                    ),
+                  IconButton(
+                    key: const Key('bulk-delete'),
+                    icon: const Icon(Icons.delete_outline),
+                    onPressed: () => controller.deleteAll(selection),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _pickBudget(BuildContext context, WidgetRef ref) async {
+    final budgets = ref.read(budgetOptionsProvider).value ?? const <Budget>[];
+
+    final chosen = await showModalBottomSheet<Budget>(
+      context: context,
+      builder: (_) => ListView(
+        children: [
+          for (final budget in budgets)
+            ListTile(
+              key: Key('budget-${budget.id}'),
+              title: Text(budget.name),
+              onTap: () => Navigator.of(context).pop(budget),
+            ),
+        ],
+      ),
+    );
+
+    if (chosen == null) return;
+
+    await ref.read(transactionsControllerProvider.notifier).bulk(ids: selection, budgetId: chosen.id);
+  }
+}
+
+class _Message extends StatelessWidget {
+  const _Message(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(32),
+          child: Text(text, textAlign: TextAlign.center),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -82,7 +82,7 @@ packages:
     source: hosted
     version: "2.16.0"
   built_collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
+  built_collection: ^5.1.1
   decimal: ^3.2.6
   device_info_plus: ^13.2.0
   dio: ^5.11.0

--- a/mobile/test/transactions/transaction_detail_test.dart
+++ b/mobile/test/transactions/transaction_detail_test.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spendable/api/api_client.dart';
+import 'package:spendable/transactions/transactions_screen.dart';
+
+import '../support/fakes.dart';
+
+Map<String, Object?> _transaction({
+  String amount = '-20.00',
+  String? transferId,
+  List<Map<String, Object?>>? allocations,
+}) => {
+  'id': 'txn_1',
+  'name': 'Market',
+  'amount': amount,
+  'date': '2026-08-14',
+  'note': null,
+  'reviewed': false,
+  'excluded': false,
+  'transfer_id': transferId,
+  'source': null,
+  'budget_allocations':
+      allocations ??
+      [
+        {'id': 'bal_1', 'amount': amount, 'budget_id': 'bgt_food'},
+      ],
+};
+
+const _budgets = [
+  {
+    'id': 'bgt_food',
+    'name': 'Food',
+    'type': 'envelope',
+    'balance': '50.00',
+    'budgeted_amount': '200.00',
+    'archived_at': null,
+  },
+  {
+    'id': 'bgt_fun',
+    'name': 'Fun',
+    'type': 'envelope',
+    'balance': '30.00',
+    'budgeted_amount': '100.00',
+    'archived_at': null,
+  },
+];
+
+const _splits = [
+  {
+    'id': 'spl_payday',
+    'name': 'Payday',
+    'archived_at': null,
+    'split_lines': [
+      {'id': 'spll_1', 'amount': '-12.00', 'budget_id': 'bgt_food'},
+      {'id': 'spll_2', 'amount': '-8.00', 'budget_id': 'bgt_fun'},
+    ],
+  },
+];
+
+/// Opens the sheet the way the screen does, so the detail is exercised against a real list.
+Future<FakeApi> _open(
+  WidgetTester tester, {
+  Map<String, Object?>? transaction,
+  Map<String, ({int status, Object? body})>? extra,
+}) async {
+  final api = FakeApi({
+    'GET /api/transactions': (status: 200, body: [transaction ?? _transaction()]),
+    'GET /api/budgets': (status: 200, body: _budgets),
+    'GET /api/splits': (status: 200, body: _splits),
+    ...?extra,
+  });
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [apiProvider.overrideWithValue(api.build())],
+      child: const MaterialApp(home: TransactionsScreen()),
+    ),
+  );
+
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Market'));
+  await tester.pumpAndSettle();
+
+  return api;
+}
+
+void main() {
+  // A transaction with one allocation splits nothing, so only the budget is worth asking about.
+  testWidgets('a single allocation offers just the budget', (tester) async {
+    await _open(tester);
+
+    expect(find.byKey(const Key('allocation-budget-0')), findsOneWidget);
+    expect(find.byKey(const Key('allocation-amount-0')), findsNothing);
+    expect(find.text('Spend from'), findsOneWidget);
+  });
+
+  testWidgets('money coming in reads as adding to a budget', (tester) async {
+    await _open(tester, transaction: _transaction(amount: '20.00'));
+
+    expect(find.text('Add to'), findsOneWidget);
+  });
+
+  testWidgets('a split transaction shows an amount against each budget', (tester) async {
+    await _open(
+      tester,
+      transaction: _transaction(
+        allocations: [
+          {'id': 'bal_1', 'amount': '-12.00', 'budget_id': 'bgt_food'},
+          {'id': 'bal_2', 'amount': '-8.00', 'budget_id': 'bgt_fun'},
+        ],
+      ),
+    );
+
+    expect(find.byKey(const Key('allocation-amount-0')), findsOneWidget);
+    expect(find.byKey(const Key('allocation-amount-1')), findsOneWidget);
+  });
+
+  // A single allocation carries the whole amount, so the line follows the amount field.
+  testWidgets('saving one allocation sends the whole amount against it', (tester) async {
+    final api = await _open(
+      tester,
+      extra: {'PATCH /api/transactions/txn_1': (status: 200, body: _transaction(amount: '-25.00'))},
+    );
+
+    await tester.enterText(find.byKey(const Key('transaction-amount')), '-25.00');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('transaction-save')));
+    await tester.pumpAndSettle();
+
+    final sent = api.requests.last.data! as Map<String, dynamic>;
+
+    expect(sent['amount'], '-25.00');
+    expect(sent['budget_allocations'], [
+      {'id': 'bal_1', 'amount': '-25.00', 'budget_id': 'bgt_food'},
+    ]);
+  });
+
+  testWidgets('applying a split replaces the lines with the split lines', (tester) async {
+    final api = await _open(
+      tester,
+      extra: {'PATCH /api/transactions/txn_1': (status: 200, body: _transaction())},
+    );
+
+    await tester.tap(find.byKey(const Key('apply-split')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('split-spl_payday')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('allocation-amount-1')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('transaction-save')));
+    await tester.pumpAndSettle();
+
+    final sent = api.requests.last.data! as Map<String, dynamic>;
+
+    // The split's own line ids belong to the split, not to this transaction.
+    expect(sent['budget_allocations'], [
+      {'amount': '-12.00', 'budget_id': 'bgt_food'},
+      {'amount': '-8.00', 'budget_id': 'bgt_fun'},
+    ]);
+  });
+
+  testWidgets('removing a transfer closes the sheet and refreshes the row', (tester) async {
+    final api = await _open(
+      tester,
+      transaction: _transaction(transferId: 'txn_2'),
+      extra: {'DELETE /api/transactions/txn_1/transfer': (status: 200, body: _transaction())},
+    );
+
+    await tester.ensureVisible(find.byKey(const Key('remove-transfer')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('remove-transfer')));
+    await tester.pumpAndSettle();
+
+    expect(api.requests.map((request) => request.method), contains('DELETE'));
+    expect(find.byKey(const Key('transaction-save')), findsNothing);
+    expect(find.textContaining('Transfer'), findsNothing);
+  });
+
+  testWidgets('a rejected save keeps the sheet open with the error on the line', (tester) async {
+    await _open(
+      tester,
+      transaction: _transaction(
+        allocations: [
+          {'id': 'bal_1', 'amount': '-12.00', 'budget_id': 'bgt_food'},
+          {'id': 'bal_2', 'amount': '-8.00', 'budget_id': 'bgt_fun'},
+        ],
+      ),
+      extra: {
+        'PATCH /api/transactions/txn_1': (
+          status: 422,
+          body: {
+            'errors': [
+              {
+                'code': 'invalid',
+                'detail': 'is invalid',
+                'source': {'pointer': '/budget_allocations/1/amount'},
+              },
+            ],
+          },
+        ),
+      },
+    );
+
+    await tester.enterText(find.byKey(const Key('allocation-amount-1')), 'nope');
+    await tester.tap(find.byKey(const Key('transaction-save')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('transaction-save')), findsOneWidget);
+    expect(find.text('is invalid'), findsOneWidget);
+  });
+}

--- a/mobile/test/transactions/transactions_screen_test.dart
+++ b/mobile/test/transactions/transactions_screen_test.dart
@@ -1,0 +1,271 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spendable/api/api_client.dart';
+import 'package:spendable/transactions/transactions_screen.dart';
+
+import '../support/fakes.dart';
+
+Map<String, Object?> _transaction(
+  String id,
+  String name, {
+  String amount = '-20.00',
+  bool reviewed = false,
+  bool excluded = false,
+  String? transferId,
+  List<Map<String, Object?>>? allocations,
+}) => {
+  'id': id,
+  'name': name,
+  'amount': amount,
+  'date': '2026-08-14',
+  'note': null,
+  'reviewed': reviewed,
+  'excluded': excluded,
+  'transfer_id': transferId,
+  'source': null,
+  'budget_allocations':
+      allocations ??
+      [
+        {'id': 'bal_$id', 'amount': amount, 'budget_id': 'bgt_food'},
+      ],
+};
+
+const _budgets = [
+  {
+    'id': 'bgt_food',
+    'name': 'Food',
+    'type': 'envelope',
+    'balance': '50.00',
+    'budgeted_amount': '200.00',
+    'archived_at': null,
+  },
+  {
+    'id': 'bgt_fun',
+    'name': 'Fun',
+    'type': 'envelope',
+    'balance': '30.00',
+    'budgeted_amount': '100.00',
+    'archived_at': null,
+  },
+];
+
+const _splits = [
+  {
+    'id': 'spl_payday',
+    'name': 'Payday',
+    'archived_at': null,
+    'split_lines': [
+      {'id': 'spll_1', 'amount': '-12.00', 'budget_id': 'bgt_food'},
+      {'id': 'spll_2', 'amount': '-8.00', 'budget_id': 'bgt_fun'},
+    ],
+  },
+];
+
+Map<String, ({int status, Object? body})> _replies([Map<String, ({int status, Object? body})>? extra]) => {
+  'GET /api/transactions': (status: 200, body: [_transaction('txn_1', 'Market')]),
+  'GET /api/budgets': (status: 200, body: _budgets),
+  'GET /api/splits': (status: 200, body: _splits),
+  ...?extra,
+};
+
+Future<FakeApi> _pump(WidgetTester tester, {Map<String, ({int status, Object? body})>? replies}) async {
+  final api = FakeApi(replies ?? _replies());
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [apiProvider.overrideWithValue(api.build())],
+      child: const MaterialApp(home: TransactionsScreen()),
+    ),
+  );
+
+  await tester.pumpAndSettle();
+
+  return api;
+}
+
+void main() {
+  // The API hides reviewed rows unless asked; the screen is a queue and wants them shown.
+  testWidgets('asks for reviewed rows and hides excluded ones', (tester) async {
+    final api = await _pump(tester);
+
+    expect(api.requests.first.queryParameters['show_reviewed'], true);
+    expect(api.requests.first.queryParameters['show_excluded'], false);
+  });
+
+  testWidgets('lists a transaction with its date and amount', (tester) async {
+    await _pump(tester);
+
+    expect(find.text('Market'), findsOneWidget);
+    expect(find.text(r'-$20.00'), findsOneWidget);
+    expect(find.textContaining('Aug 14, 2026'), findsOneWidget);
+  });
+
+  // Reviewing is what clears the queue, so the row has to leave when it no longer matches.
+  testWidgets('a reviewed row drops out of the list when reviewed rows are hidden', (tester) async {
+    await _pump(
+      tester,
+      replies: _replies({
+        'PATCH /api/transactions/txn_1': (status: 200, body: _transaction('txn_1', 'Market', reviewed: true)),
+      }),
+    );
+
+    await tester.tap(find.byKey(const Key('open-filters')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('filter-reviewed')));
+    await tester.pumpAndSettle();
+
+    // Dismiss the sheet by tapping its barrier.
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('reviewed-txn_1')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Market'), findsNothing);
+  });
+
+  testWidgets('a reviewed row stays when reviewed rows are shown', (tester) async {
+    await _pump(
+      tester,
+      replies: _replies({
+        'PATCH /api/transactions/txn_1': (status: 200, body: _transaction('txn_1', 'Market', reviewed: true)),
+      }),
+    );
+
+    await tester.tap(find.byKey(const Key('reviewed-txn_1')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Market'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+
+  testWidgets('selecting two rows offers a transfer', (tester) async {
+    final api = await _pump(
+      tester,
+      replies: _replies({
+        'GET /api/transactions': (
+          status: 200,
+          body: [
+            _transaction('txn_1', 'Out'),
+            _transaction('txn_2', 'In', amount: '20.00'),
+          ],
+        ),
+        'POST /api/transactions/transfer': (
+          status: 200,
+          body: [
+            _transaction('txn_1', 'Out', transferId: 'txn_2'),
+            _transaction('txn_2', 'In', amount: '20.00', transferId: 'txn_1'),
+          ],
+        ),
+      }),
+    );
+
+    await tester.tap(find.byKey(const Key('select-txn_1')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('bulk-transfer')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('select-txn_2')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('bulk-transfer')));
+    await tester.pumpAndSettle();
+
+    expect(api.requests.last.data, containsPair('transaction_ids', ['txn_1', 'txn_2']));
+    expect(find.textContaining('Transfer'), findsWidgets);
+  });
+
+  testWidgets('a refused transfer says why and leaves the rows alone', (tester) async {
+    await _pump(
+      tester,
+      replies: _replies({
+        'GET /api/transactions': (
+          status: 200,
+          body: [_transaction('txn_1', 'Out'), _transaction('txn_2', 'Also out')],
+        ),
+        'POST /api/transactions/transfer': (
+          status: 409,
+          body: {
+            'errors': [
+              {'code': 'transfer_not_allowed', 'detail': 'needs one leaving and one arriving'},
+            ],
+          },
+        ),
+      }),
+    );
+
+    await tester.tap(find.byKey(const Key('select-txn_1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('select-txn_2')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('bulk-transfer')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('needs one leaving and one arriving'), findsOneWidget);
+  });
+
+  testWidgets('bulk review applies to everything selected and clears the selection', (tester) async {
+    final api = await _pump(
+      tester,
+      replies: _replies({
+        'GET /api/transactions': (
+          status: 200,
+          body: [_transaction('txn_1', 'Market'), _transaction('txn_2', 'Coffee')],
+        ),
+        'PATCH /api/transactions/bulk': (
+          status: 200,
+          body: {
+            'transactions': [
+              _transaction('txn_1', 'Market', reviewed: true),
+              _transaction('txn_2', 'Coffee', reviewed: true),
+            ],
+            'failed': <Object>[],
+          },
+        ),
+      }),
+    );
+
+    await tester.tap(find.byKey(const Key('select-txn_1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('select-txn_2')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('bulk-review')));
+    await tester.pumpAndSettle();
+
+    expect(api.requests.last.data, containsPair('reviewed', true));
+    expect(find.byKey(const Key('bulk-review')), findsNothing);
+    expect(find.byIcon(Icons.check_circle), findsNWidgets(2));
+  });
+
+  // A bulk delete is applied per transaction, so the ones that failed have to stay on screen.
+  testWidgets('bulk delete keeps the rows the server could not delete', (tester) async {
+    await _pump(
+      tester,
+      replies: _replies({
+        'GET /api/transactions': (
+          status: 200,
+          body: [_transaction('txn_1', 'Market'), _transaction('txn_2', 'Coffee')],
+        ),
+        'POST /api/transactions/bulk/delete': (
+          status: 200,
+          body: {
+            'transactions': [_transaction('txn_1', 'Market')],
+            'failed': [
+              {'id': 'txn_2', 'code': 'transaction_not_found'},
+            ],
+          },
+        ),
+      }),
+    );
+
+    await tester.tap(find.byKey(const Key('select-txn_1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('select-txn_2')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('bulk-delete')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Market'), findsNothing);
+    expect(find.text('Coffee'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Stacked on #770 → #768 → #767.

Paged list, row review toggle, detail sheet with allocations and splits, multi-select bulk actions, transfers. A tab bar now holds Budgets and Transactions.

**The queue behaviour.** The API hides reviewed rows unless asked; this screen wants them, so it sends `show_reviewed` explicitly. After any write the row is replaced with what came back and dropped if it no longer matches the filters — that is what makes reviewing clear the queue, mirroring `visible?/2`.

**One allocation splits nothing**, so the sheet only asks which budget and sends the whole amount against it. Applying a split rewrites the lines locally *without* the split's own line ids; the server rebuilds the allocations on save either way, and the response is what gets rendered.

**A bug the filters had:** they auto-disposed when the sheet closed, silently resetting to defaults. The list now watches them, which both refetches on change and keeps them alive.

**Two layout fixes** the tests caught, real on a 375pt phone: the bulk action bar scrolls sideways rather than overflowing, and Save is pinned to the sheet header instead of sitting past the fold.

62 Dart tests, analyze and format clean.

Not ported: the LiveView's sliding-window pagination. That is a stream optimisation for a page that never unmounts; here pages append and the list is disposed with the tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)