### PR TITLE
Pass the iOS OAuth client id to the release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ npm-debug.log
 # Credentials for the production stack (scripts/install.sh).
 /.secrets/
 .env.prod
+
+# The Flutter build tree, ignored here as well as in mobile/.gitignore so a branch that predates
+# mobile/ cannot sweep 800MB of it into a commit.
+/mobile/build/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ x-app: &app
     # this has to be the tunnel's public hostname or LiveView will refuse to connect.
     PHX_HOST: "${PHX_HOST:-localhost}"
     PORT: "4000"
+    # An OAuth client id is a public identifier, not a secret, so it rides in the environment
+    # rather than in .secrets. The iOS app sends ID tokens with this as their audience.
+    GOOGLE_IOS_CLIENT_ID: "${GOOGLE_IOS_CLIENT_ID:-}"
   volumes:
     - ./.secrets:/etc/secrets:ro
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,6 +54,20 @@ ask_secret() {
   write_secret "$name" "$value"
 }
 
+# A public identifier rather than a credential, so it stays out of .secrets and lands in
+# .env.prod, which is where compose reads it from. Answers may be empty. $1 name, $2 prompt.
+ask_public() {
+  local name="$1" label="$2" current="" suffix="" value=""
+
+  [ -f "$ENV_FILE" ] && current="$(sed -n "s/^$name=//p" "$ENV_FILE")"
+
+  [ -n "$current" ] && suffix=" [keep existing]"
+
+  read -rp "$label$suffix: " value
+
+  printf -v "$name" '%s' "${value:-$current}"
+}
+
 echo "Spendable production install"
 echo
 
@@ -64,6 +78,9 @@ echo
 echo "Google OAuth (console.cloud.google.com)"
 ask_secret GOOGLE_CLIENT_ID "  Client ID"
 ask_secret GOOGLE_CLIENT_SECRET "  Client secret" hidden
+# Without this the iOS app can sign in nowhere: its ID tokens carry the iOS client as audience,
+# and the web client id above will not match them. Blank is fine until the app ships.
+ask_public GOOGLE_IOS_CLIENT_ID "  iOS client ID (blank if there is no iOS app yet)"
 
 echo
 echo "Plaid (dashboard.plaid.com)"
@@ -97,12 +114,13 @@ if [[ "$use_tunnel" =~ ^[Yy] ]]; then
   tunnel_token="$(cat "$SECRETS/CLOUDFLARE_TUNNEL_TOKEN")"
 fi
 
-# Compose needs three of these for its own variable substitution, so they are duplicated out of
-# .secrets into a file only this user can read. The rest never leave .secrets.
+# Compose needs these for its own variable substitution, so the credentials among them are
+# duplicated out of .secrets into a file only this user can read. The rest never leave .secrets.
 {
   echo "PHX_HOST=$hostname"
   echo "POSTGRES_PASSWORD=$(cat "$SECRETS/DB_PASSWORD")"
   echo "TUNNEL_TOKEN=$tunnel_token"
+  echo "GOOGLE_IOS_CLIENT_ID=$GOOGLE_IOS_CLIENT_ID"
   # Behind a tunnel nothing needs to reach the app from outside this machine, so bind loopback only.
   if [ -n "$tunnel_token" ]; then
     echo "PROD_PORT=127.0.0.1:4000"


### PR DESCRIPTION
`GOOGLE_IOS_CLIENT_ID` is read with `System.get_env/1` in [config/runtime.exs:32](config/runtime.exs:32), but nothing put it in the app container's environment — so an iOS sign-in would have been rejected on audience no matter what was exported on the host.

It goes in `.env.prod` alongside `PHX_HOST` rather than in `.secrets/`: an OAuth client id is a public identifier that ships inside the app bundle, not a credential. `scripts/install.sh` grows an `ask_public` helper for exactly that distinction, with the same keep-existing behaviour as the secret prompts, and accepts a blank answer.

Also ignores `/mobile/build/` from the root. `mobile/.gitignore` already covers it, but only on branches that have `mobile/` — this branch does not, and `git add -A` cheerfully staged 800MB of build output before I caught it.

Verified `docker compose config` resolves the variable into the app service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)