### PR TITLE
Claim the Plaid OAuth redirect on the device

### DIFF
--- a/mobile/ios/Runner/Runner.entitlements
+++ b/mobile/ios/Runner/Runner.entitlements
@@ -6,5 +6,12 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<!-- Lets the app claim spendable.money links, which is how a bank's OAuth page returns to
+	     Plaid Link instead of stranding the user in Safari. The server answers the matching
+	     apple-app-site-association. -->
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:spendable.money</string>
+	</array>
 </dict>
 </plist>

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'auth/auth_controller.dart';
 import 'auth/sign_in_screen.dart';
+import 'banks/plaid_oauth_links.dart';
 import 'shell.dart';
 import 'theme.dart';
 
@@ -12,6 +13,9 @@ class SpendableApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final auth = ref.watch(authStateProvider);
+
+    // Nothing renders it; it just has to be alive to catch a bank's OAuth redirect on launch.
+    ref.watch(plaidOAuthResumeProvider);
 
     return MaterialApp(
       title: 'Spendable',

--- a/mobile/lib/banks/banks_controller.dart
+++ b/mobile/lib/banks/banks_controller.dart
@@ -4,12 +4,15 @@ import 'package:spendable_api/spendable_api.dart';
 import '../api/api_client.dart';
 import '../api/api_error.dart';
 import 'banks_providers.dart';
+import 'pending_plaid_session.dart';
 import 'plaid_link_flow.dart';
 
 part 'banks_controller.g.dart';
 
-/// Connecting banks and deciding what each account does.
-@riverpod
+/// Connecting banks and deciding what each account does. Kept alive because a resumed OAuth
+/// redirect reaches it before any screen is watching, and an auto-disposed notifier would be
+/// collected out from under the write.
+@Riverpod(keepAlive: true)
 class BanksController extends _$BanksController {
   @override
   AsyncValue<void> build() => const AsyncData(null);
@@ -18,21 +21,38 @@ class BanksController extends _$BanksController {
   /// having been sent through Link for nothing.
   Future<bool> connect() => _write(() async {
     final response = await _api.createLinkToken().orApiError();
-    final publicToken = await ref.read(plaidLinkFlowProvider).open(response.data!.linkToken);
 
-    if (publicToken == null) return;
+    await _session.start(PlaidSessionKind.connect);
 
-    final request = ConnectRequest((builder) => builder.publicToken = publicToken);
-
-    await _api.createBank(connectRequest: request).orApiError();
+    await _exchange(await ref.read(plaidLinkFlowProvider).open(response.data!.linkToken));
   });
 
-  /// Reopening an existing connection: Plaid hands back no new public token, so there is nothing
-  /// to post - the item is repaired in place and the list just needs re-reading.
+  /// Reopening an existing connection: Plaid hands back no token worth exchanging, so the item is
+  /// repaired in place and the list just needs re-reading.
   Future<bool> reconnect(String memberId) => _write(() async {
     final response = await _api.createUpdateLinkToken(id: memberId).orApiError();
 
+    await _session.start(PlaidSessionKind.reconnect);
+
     await ref.read(plaidLinkFlowProvider).open(response.data!.linkToken);
+
+    await _session.clear();
+  });
+
+  /// iOS terminated the app while the user was on the bank's OAuth page, and the redirect has
+  /// brought it back. Only a connect has anything left to finish.
+  Future<bool> resumeOAuth(String redirectUri) => _write(() async {
+    final kind = await _session.read();
+
+    if (kind == null) return;
+
+    final publicToken = await ref.read(plaidLinkFlowProvider).resume(redirectUri);
+
+    if (kind == PlaidSessionKind.connect) {
+      await _exchange(publicToken);
+    } else {
+      await _session.clear();
+    }
   });
 
   Future<bool> setSync(BankAccount account, {required bool sync}) =>
@@ -46,6 +66,20 @@ class BanksController extends _$BanksController {
   Future<bool> syncHistory(String memberId) => _write(() => _api.syncBank(id: memberId).orApiError());
 
   BanksApi get _api => ref.read(apiProvider).getBanksApi();
+
+  PendingPlaidSession get _session => ref.read(pendingPlaidSessionProvider);
+
+  /// Cleared before the exchange rather than after, so a failure there cannot leave a session
+  /// pending that the next launch would try to finish again.
+  Future<void> _exchange(String? publicToken) async {
+    await _session.clear();
+
+    if (publicToken == null) return;
+
+    final request = ConnectRequest((builder) => builder.publicToken = publicToken);
+
+    await _api.createBank(connectRequest: request).orApiError();
+  }
 
   Future<bool> _updateAccount(String id, BankAccountRequest request) =>
       _write(() => _api.updateBankAccount(id: id, bankAccountRequest: request).orApiError());

--- a/mobile/lib/banks/banks_controller.g.dart
+++ b/mobile/lib/banks/banks_controller.g.dart
@@ -8,22 +8,28 @@ part of 'banks_controller.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// Connecting banks and deciding what each account does.
+/// Connecting banks and deciding what each account does. Kept alive because a resumed OAuth
+/// redirect reaches it before any screen is watching, and an auto-disposed notifier would be
+/// collected out from under the write.
 
 @ProviderFor(BanksController)
 final banksControllerProvider = BanksControllerProvider._();
 
-/// Connecting banks and deciding what each account does.
+/// Connecting banks and deciding what each account does. Kept alive because a resumed OAuth
+/// redirect reaches it before any screen is watching, and an auto-disposed notifier would be
+/// collected out from under the write.
 final class BanksControllerProvider
     extends $NotifierProvider<BanksController, AsyncValue<void>> {
-  /// Connecting banks and deciding what each account does.
+  /// Connecting banks and deciding what each account does. Kept alive because a resumed OAuth
+  /// redirect reaches it before any screen is watching, and an auto-disposed notifier would be
+  /// collected out from under the write.
   BanksControllerProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
         name: r'banksControllerProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -44,9 +50,11 @@ final class BanksControllerProvider
   }
 }
 
-String _$banksControllerHash() => r'713c7e4a5bf21210234f0c49a844c830c9a6b09f';
+String _$banksControllerHash() => r'd41105980e07df6f9e14e0c1bd3e1ca97a18a75e';
 
-/// Connecting banks and deciding what each account does.
+/// Connecting banks and deciding what each account does. Kept alive because a resumed OAuth
+/// redirect reaches it before any screen is watching, and an auto-disposed notifier would be
+/// collected out from under the write.
 
 abstract class _$BanksController extends $Notifier<AsyncValue<void>> {
   AsyncValue<void> build();

--- a/mobile/lib/banks/pending_plaid_session.dart
+++ b/mobile/lib/banks/pending_plaid_session.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'pending_plaid_session.g.dart';
+
+/// Connecting a new bank ends by exchanging a public token; repairing an existing one ends by
+/// doing nothing at all. The redirect that brings the app back says nothing about which, so the
+/// answer has to survive iOS terminating the app mid-flow.
+enum PlaidSessionKind { connect, reconnect }
+
+abstract interface class PendingPlaidSession {
+  Future<PlaidSessionKind?> read();
+
+  Future<void> start(PlaidSessionKind kind);
+
+  Future<void> clear();
+}
+
+/// The Keychain rather than shared preferences, only because the app already depends on it -
+/// nothing here is sensitive.
+class StoredPendingPlaidSession implements PendingPlaidSession {
+  StoredPendingPlaidSession([FlutterSecureStorage? storage])
+    : _storage = storage ?? const FlutterSecureStorage();
+
+  static const _key = 'pending_plaid_session';
+
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<PlaidSessionKind?> read() async {
+    final name = await _storage.read(key: _key);
+
+    return PlaidSessionKind.values.where((kind) => kind.name == name).firstOrNull;
+  }
+
+  @override
+  Future<void> start(PlaidSessionKind kind) => _storage.write(key: _key, value: kind.name);
+
+  @override
+  Future<void> clear() => _storage.delete(key: _key);
+}
+
+@Riverpod(keepAlive: true)
+PendingPlaidSession pendingPlaidSession(Ref ref) => StoredPendingPlaidSession();

--- a/mobile/lib/banks/pending_plaid_session.g.dart
+++ b/mobile/lib/banks/pending_plaid_session.g.dart
@@ -1,0 +1,58 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pending_plaid_session.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(pendingPlaidSession)
+final pendingPlaidSessionProvider = PendingPlaidSessionProvider._();
+
+final class PendingPlaidSessionProvider
+    extends
+        $FunctionalProvider<
+          PendingPlaidSession,
+          PendingPlaidSession,
+          PendingPlaidSession
+        >
+    with $Provider<PendingPlaidSession> {
+  PendingPlaidSessionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'pendingPlaidSessionProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$pendingPlaidSessionHash();
+
+  @$internal
+  @override
+  $ProviderElement<PendingPlaidSession> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  PendingPlaidSession create(Ref ref) {
+    return pendingPlaidSession(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(PendingPlaidSession value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<PendingPlaidSession>(value),
+    );
+  }
+}
+
+String _$pendingPlaidSessionHash() =>
+    r'810a6db15cac2909ad665c5256c858a53a306ef6';

--- a/mobile/lib/banks/plaid_link_flow.dart
+++ b/mobile/lib/banks/plaid_link_flow.dart
@@ -9,14 +9,25 @@ part 'plaid_link_flow.g.dart';
 /// interface because PlaidLink is a set of static methods over a platform channel.
 abstract interface class PlaidLinkFlow {
   Future<String?> open(String linkToken);
+
+  /// Picks a session back up after iOS terminated the app while the user was on the bank's OAuth
+  /// page. The redirect that brought the app back is the only state Link needs.
+  Future<String?> resume(String redirectUri);
 }
 
 class PlatformPlaidLinkFlow implements PlaidLinkFlow {
   @override
-  Future<String?> open(String linkToken) async {
+  Future<String?> open(String linkToken) =>
+      _awaiting(() => PlaidLink.create(configuration: LinkTokenConfiguration(token: linkToken)));
+
+  @override
+  Future<String?> resume(String redirectUri) =>
+      _awaiting(() => PlaidLink.resumeAfterTermination(redirectUri));
+
+  /// Both entry points end the same way: exactly one of onSuccess and onExit fires.
+  Future<String?> _awaiting(Future<void> Function() start) async {
     final result = Completer<String?>();
 
-    // Whichever fires first ends the session; the other stream never fires for it.
     final success = PlaidLink.onSuccess.listen((event) {
       if (!result.isCompleted) result.complete(event.publicToken);
     });
@@ -26,7 +37,7 @@ class PlatformPlaidLinkFlow implements PlaidLinkFlow {
     });
 
     try {
-      await PlaidLink.create(configuration: LinkTokenConfiguration(token: linkToken));
+      await start();
       await PlaidLink.open();
 
       return await result.future;

--- a/mobile/lib/banks/plaid_oauth_links.dart
+++ b/mobile/lib/banks/plaid_oauth_links.dart
@@ -1,0 +1,22 @@
+import 'package:app_links/app_links.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'banks_controller.dart';
+
+part 'plaid_oauth_links.g.dart';
+
+/// Universal links the app is opened with. The first one is included, which is the case that
+/// matters here - the app was not running when the bank redirected.
+@Riverpod(keepAlive: true)
+Stream<Uri> incomingLinks(Ref ref) => AppLinks().uriLinkStream;
+
+/// Finishes a bank connection the user started before iOS terminated the app on them. Watched
+/// from the root so it is listening whichever screen they land on.
+@Riverpod(keepAlive: true)
+void plaidOAuthResume(Ref ref) {
+  ref.listen(incomingLinksProvider, (_, next) {
+    if (next case AsyncData(value: final uri) when uri.path == '/plaid-oauth') {
+      ref.read(banksControllerProvider.notifier).resumeOAuth(uri.toString());
+    }
+  });
+}

--- a/mobile/lib/banks/plaid_oauth_links.g.dart
+++ b/mobile/lib/banks/plaid_oauth_links.g.dart
@@ -1,0 +1,99 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'plaid_oauth_links.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Universal links the app is opened with. The first one is included, which is the case that
+/// matters here - the app was not running when the bank redirected.
+
+@ProviderFor(incomingLinks)
+final incomingLinksProvider = IncomingLinksProvider._();
+
+/// Universal links the app is opened with. The first one is included, which is the case that
+/// matters here - the app was not running when the bank redirected.
+
+final class IncomingLinksProvider
+    extends $FunctionalProvider<AsyncValue<Uri>, Uri, Stream<Uri>>
+    with $FutureModifier<Uri>, $StreamProvider<Uri> {
+  /// Universal links the app is opened with. The first one is included, which is the case that
+  /// matters here - the app was not running when the bank redirected.
+  IncomingLinksProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'incomingLinksProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$incomingLinksHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<Uri> $createElement($ProviderPointer pointer) =>
+      $StreamProviderElement(pointer);
+
+  @override
+  Stream<Uri> create(Ref ref) {
+    return incomingLinks(ref);
+  }
+}
+
+String _$incomingLinksHash() => r'd9c4f72d209beb8c9af9253cf60de9194c41bf84';
+
+/// Finishes a bank connection the user started before iOS terminated the app on them. Watched
+/// from the root so it is listening whichever screen they land on.
+
+@ProviderFor(plaidOAuthResume)
+final plaidOAuthResumeProvider = PlaidOAuthResumeProvider._();
+
+/// Finishes a bank connection the user started before iOS terminated the app on them. Watched
+/// from the root so it is listening whichever screen they land on.
+
+final class PlaidOAuthResumeProvider
+    extends $FunctionalProvider<void, void, void>
+    with $Provider<void> {
+  /// Finishes a bank connection the user started before iOS terminated the app on them. Watched
+  /// from the root so it is listening whichever screen they land on.
+  PlaidOAuthResumeProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'plaidOAuthResumeProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$plaidOAuthResumeHash();
+
+  @$internal
+  @override
+  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  void create(Ref ref) {
+    return plaidOAuthResume(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$plaidOAuthResumeHash() => r'579f2c8195eb67be560204a57be0ffd5e1be1cfd';

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -25,6 +25,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.3"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: f8db46d2ea9ff6f3a37191a7fd5b7813da1253ace8c32c1b9eadace41d1188ea
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.1"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "7546f09a6e93f4a2df2fe2bd40a5c6c64310ac461b036d82b43033be7a59f809"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   args:
     dependency: transitive
     description:
@@ -424,6 +456,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: "4ff85b2a16724029dd9e5bbb5a94b6918f9973f74ba571c949d2002801879cf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   hooks:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.13.0
 
 dependencies:
+  app_links: ^7.2.1
   built_collection: ^5.1.1
   decimal: ^3.2.6
   device_info_plus: ^13.2.0

--- a/mobile/test/banks/banks_screen_test.dart
+++ b/mobile/test/banks/banks_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spendable/api/api_client.dart';
 import 'package:spendable/banks/banks_screen.dart';
+import 'package:spendable/banks/pending_plaid_session.dart';
 import 'package:spendable/banks/plaid_link_flow.dart';
 
 import '../support/fakes.dart';
@@ -14,6 +15,7 @@ class FakePlaidLinkFlow implements PlaidLinkFlow {
   final String? publicToken;
 
   final opened = <String>[];
+  final resumed = <String>[];
 
   @override
   Future<String?> open(String linkToken) async {
@@ -21,6 +23,28 @@ class FakePlaidLinkFlow implements PlaidLinkFlow {
 
     return publicToken;
   }
+
+  @override
+  Future<String?> resume(String redirectUri) async {
+    resumed.add(redirectUri);
+
+    return publicToken;
+  }
+}
+
+class FakePendingPlaidSession implements PendingPlaidSession {
+  FakePendingPlaidSession([this.kind]);
+
+  PlaidSessionKind? kind;
+
+  @override
+  Future<PlaidSessionKind?> read() async => kind;
+
+  @override
+  Future<void> start(PlaidSessionKind value) async => kind = value;
+
+  @override
+  Future<void> clear() async => kind = null;
 }
 
 Map<String, Object?> _account(
@@ -70,13 +94,18 @@ Future<(FakeApi, FakePlaidLinkFlow)> _pump(
   WidgetTester tester, {
   Map<String, ({int status, Object? body})>? replies,
   FakePlaidLinkFlow? plaid,
+  FakePendingPlaidSession? session,
 }) async {
   final api = FakeApi(replies ?? _replies());
   final link = plaid ?? FakePlaidLinkFlow();
 
   await tester.pumpWidget(
     ProviderScope(
-      overrides: [apiProvider.overrideWithValue(api.build()), plaidLinkFlowProvider.overrideWithValue(link)],
+      overrides: [
+        apiProvider.overrideWithValue(api.build()),
+        plaidLinkFlowProvider.overrideWithValue(link),
+        pendingPlaidSessionProvider.overrideWithValue(session ?? FakePendingPlaidSession()),
+      ],
       child: const MaterialApp(home: BanksScreen()),
     ),
   );

--- a/mobile/test/banks/plaid_oauth_resume_test.dart
+++ b/mobile/test/banks/plaid_oauth_resume_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spendable/api/api_client.dart';
+import 'package:spendable/banks/banks_controller.dart';
+import 'package:spendable/banks/pending_plaid_session.dart';
+import 'package:spendable/banks/plaid_link_flow.dart';
+
+import '../support/fakes.dart';
+import 'banks_screen_test.dart' show FakePendingPlaidSession, FakePlaidLinkFlow;
+
+const _member = {
+  'id': 'bkm_1',
+  'name': 'Chase',
+  'provider': 'Plaid',
+  'status': 'CONNECTED',
+  'has_logo': false,
+  'bank_accounts': <Object>[],
+};
+
+ProviderContainer _container({
+  required FakeApi api,
+  required FakePlaidLinkFlow link,
+  required FakePendingPlaidSession session,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      apiProvider.overrideWithValue(api.build()),
+      plaidLinkFlowProvider.overrideWithValue(link),
+      pendingPlaidSessionProvider.overrideWithValue(session),
+    ],
+  );
+
+  addTearDown(container.dispose);
+
+  return container;
+}
+
+void main() {
+  // iOS killed the app on the bank's OAuth page. The redirect brings it back with no memory of
+  // the flow beyond what was written down before Link opened.
+  test('a resumed connect exchanges the public token', () async {
+    final api = FakeApi({
+      'POST /api/banks': (status: 201, body: _member),
+      'GET /api/banks': (status: 200, body: [_member]),
+    });
+    final link = FakePlaidLinkFlow('public-resumed');
+    final session = FakePendingPlaidSession(PlaidSessionKind.connect);
+
+    final container = _container(api: api, link: link, session: session);
+
+    await container
+        .read(banksControllerProvider.notifier)
+        .resumeOAuth('https://spendable.money/plaid-oauth?oauth_state_id=abc');
+
+    expect(link.resumed, ['https://spendable.money/plaid-oauth?oauth_state_id=abc']);
+    expect(api.requests.map((request) => '${request.method} ${request.path}'), contains('POST /api/banks'));
+    expect(session.kind, isNull);
+  });
+
+  // Repairing an item hands back nothing worth exchanging, so posting it would create a duplicate
+  // connection for a bank the user already has.
+  test('a resumed reconnect exchanges nothing', () async {
+    final api = FakeApi({
+      'GET /api/banks': (status: 200, body: [_member]),
+    });
+    final link = FakePlaidLinkFlow('public-resumed');
+    final session = FakePendingPlaidSession(PlaidSessionKind.reconnect);
+
+    final container = _container(api: api, link: link, session: session);
+
+    await container.read(banksControllerProvider.notifier).resumeOAuth('https://spendable.money/plaid-oauth');
+
+    expect(link.resumed, hasLength(1));
+    expect(
+      api.requests.map((request) => '${request.method} ${request.path}'),
+      isNot(contains('POST /api/banks')),
+    );
+    expect(session.kind, isNull);
+  });
+
+  // A stray visit to the redirect with nothing in flight must not open Link at all.
+  test('a redirect with no session in flight does nothing', () async {
+    final api = FakeApi({
+      'GET /api/banks': (status: 200, body: [_member]),
+    });
+    final link = FakePlaidLinkFlow('public-resumed');
+
+    final container = _container(api: api, link: link, session: FakePendingPlaidSession());
+
+    await container.read(banksControllerProvider.notifier).resumeOAuth('https://spendable.money/plaid-oauth');
+
+    expect(link.resumed, isEmpty);
+    expect(
+      api.requests.map((request) => '${request.method} ${request.path}'),
+      isNot(contains('POST /api/banks')),
+    );
+  });
+
+  // Otherwise a failed exchange leaves a session pending that the next launch tries again.
+  test('a connect that Link abandons clears the session', () async {
+    final api = FakeApi({
+      'POST /api/banks/link_token': (status: 200, body: {'link_token': 'link-new'}),
+      'GET /api/banks': (status: 200, body: [_member]),
+    });
+    final session = FakePendingPlaidSession();
+
+    final container = _container(api: api, link: FakePlaidLinkFlow(), session: session);
+
+    await container.read(banksControllerProvider.notifier).connect();
+
+    expect(session.kind, isNull);
+    expect(
+      api.requests.map((request) => '${request.method} ${request.path}'),
+      isNot(contains('POST /api/banks')),
+    );
+  });
+}


### PR DESCRIPTION
The device half of the Plaid OAuth fix. Pairs with #774, which serves the association file and sends the redirect URI — neither works without the other.

**The entitlement.** `com.apple.developer.associated-domains` with `applinks:spendable.money` lets the app intercept `/plaid-oauth`, which is how a bank's OAuth page returns to Link rather than stranding the user in Safari.

**Surviving termination.** iOS kills the app often enough while it sits behind the bank's page, and the redirect that brings it back carries no record of what was in flight. So the kind of session is written down before Link opens:

- a **connect** resumes and exchanges its public token
- a **reconnect** resumes and exchanges nothing — posting that token would create a second connection for a bank the user already has
- a stray visit with nothing pending does not open Link at all

The session is cleared before the exchange rather than after, so a failure there cannot leave one pending that the next launch tries again.

**A bug this surfaced:** `BanksController` was auto-disposed, and a resumed redirect reaches it before any screen is watching — the notifier was being collected out from under the write. It is keepAlive now.

80 Dart tests, analyze and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)