### PR TITLE
Stop formatting generated Dart, and catch stale codegen

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -26,7 +26,15 @@ jobs:
       - uses: jdx/mise-action@v2
 
       - run: flutter pub get
-      - run: dart format --set-exit-if-changed --line-length 110 lib test
+
+      # Regenerated rather than trusted, so a .g.dart left behind by a change to the file it is
+      # generated from fails here instead of confusing the next person to run build_runner.
+      - run: dart run build_runner build
+      - run: git diff --exit-code lib
+
+      # Generated files are excluded: build_runner writes them at its own width, so formatting
+      # them would put every regeneration at odds with the check above.
+      - run: dart format --set-exit-if-changed --line-length 110 $(find lib test -name '*.dart' ! -name '*.g.dart')
       - run: flutter analyze
       - run: flutter test
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -25,10 +25,14 @@ Needs Docker. CI fails if either the spec or the client has drifted.
 ## Gates
 
 ```sh
-dart format --set-exit-if-changed --line-length 110 lib test
+dart run build_runner build
+dart format --line-length 110 $(find lib test -name '*.dart' ! -name '*.g.dart')
 flutter analyze
 flutter test
 ```
+
+Generated `.g.dart` files are committed exactly as build_runner writes them - do not format them,
+or every regeneration will show up as a diff.
 
 ## Setup this repo cannot do for you
 

--- a/mobile/lib/api/api_client.g.dart
+++ b/mobile/lib/api/api_client.g.dart
@@ -12,7 +12,8 @@ part of 'api_client.dart';
 @ProviderFor(api)
 final apiProvider = ApiProvider._();
 
-final class ApiProvider extends $FunctionalProvider<SpendableApi, SpendableApi, SpendableApi>
+final class ApiProvider
+    extends $FunctionalProvider<SpendableApi, SpendableApi, SpendableApi>
     with $Provider<SpendableApi> {
   ApiProvider._()
     : super(
@@ -30,7 +31,8 @@ final class ApiProvider extends $FunctionalProvider<SpendableApi, SpendableApi, 
 
   @$internal
   @override
-  $ProviderElement<SpendableApi> $createElement($ProviderPointer pointer) => $ProviderElement(pointer);
+  $ProviderElement<SpendableApi> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
 
   @override
   SpendableApi create(Ref ref) {
@@ -39,7 +41,10 @@ final class ApiProvider extends $FunctionalProvider<SpendableApi, SpendableApi, 
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(SpendableApi value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<SpendableApi>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SpendableApi>(value),
+    );
   }
 }
 

--- a/mobile/lib/auth/auth_controller.g.dart
+++ b/mobile/lib/auth/auth_controller.g.dart
@@ -15,7 +15,8 @@ final deviceNameProvider = DeviceNameProvider._();
 
 /// Labels the token row so the account screen can tell one device from another.
 
-final class DeviceNameProvider extends $FunctionalProvider<AsyncValue<String?>, String?, FutureOr<String?>>
+final class DeviceNameProvider
+    extends $FunctionalProvider<AsyncValue<String?>, String?, FutureOr<String?>>
     with $FutureModifier<String?>, $FutureProvider<String?> {
   /// Labels the token row so the account screen can tell one device from another.
   DeviceNameProvider._()
@@ -34,7 +35,8 @@ final class DeviceNameProvider extends $FunctionalProvider<AsyncValue<String?>, 
 
   @$internal
   @override
-  $FutureProviderElement<String?> $createElement($ProviderPointer pointer) => $FutureProviderElement(pointer);
+  $FutureProviderElement<String?> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<String?> create(Ref ref) {
@@ -91,7 +93,12 @@ abstract class _$AuthState extends $AsyncNotifier<bool> {
     final ref = this.ref as $Ref<AsyncValue<bool>, bool>;
     final element =
         ref.element
-            as $ClassProviderElement<AnyNotifier<AsyncValue<bool>, bool>, AsyncValue<bool>, Object?, Object?>;
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<bool>, bool>,
+              AsyncValue<bool>,
+              Object?,
+              Object?
+            >;
     return element.handleCreate(ref, build);
   }
 }
@@ -102,7 +109,8 @@ abstract class _$AuthState extends $AsyncNotifier<bool> {
 final authControllerProvider = AuthControllerProvider._();
 
 /// Signing in and out. Its own state is the progress and failure of the attempt.
-final class AuthControllerProvider extends $NotifierProvider<AuthController, AsyncValue<void>> {
+final class AuthControllerProvider
+    extends $NotifierProvider<AuthController, AsyncValue<void>> {
   /// Signing in and out. Its own state is the progress and failure of the attempt.
   AuthControllerProvider._()
     : super(
@@ -124,7 +132,10 @@ final class AuthControllerProvider extends $NotifierProvider<AuthController, Asy
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<void> value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<AsyncValue<void>>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<void>>(value),
+    );
   }
 }
 

--- a/mobile/lib/auth/current_user.g.dart
+++ b/mobile/lib/auth/current_user.g.dart
@@ -15,7 +15,8 @@ final currentUserProvider = CurrentUserProvider._();
 
 /// The account behind the stored token. Invalidate after anything that changes it.
 
-final class CurrentUserProvider extends $FunctionalProvider<AsyncValue<User>, User, FutureOr<User>>
+final class CurrentUserProvider
+    extends $FunctionalProvider<AsyncValue<User>, User, FutureOr<User>>
     with $FutureModifier<User>, $FutureProvider<User> {
   /// The account behind the stored token. Invalidate after anything that changes it.
   CurrentUserProvider._()
@@ -34,7 +35,8 @@ final class CurrentUserProvider extends $FunctionalProvider<AsyncValue<User>, Us
 
   @$internal
   @override
-  $FutureProviderElement<User> $createElement($ProviderPointer pointer) => $FutureProviderElement(pointer);
+  $FutureProviderElement<User> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<User> create(Ref ref) {

--- a/mobile/lib/auth/identity_controller.g.dart
+++ b/mobile/lib/auth/identity_controller.g.dart
@@ -16,7 +16,8 @@ final identityControllerProvider = IdentityControllerProvider._();
 
 /// Attaching and removing ways of signing in. Linking is an authenticated action rather than
 /// something inferred from a shared email, because Spendable stores no email to match on.
-final class IdentityControllerProvider extends $NotifierProvider<IdentityController, AsyncValue<void>> {
+final class IdentityControllerProvider
+    extends $NotifierProvider<IdentityController, AsyncValue<void>> {
   /// Attaching and removing ways of signing in. Linking is an authenticated action rather than
   /// something inferred from a shared email, because Spendable stores no email to match on.
   IdentityControllerProvider._()
@@ -39,11 +40,15 @@ final class IdentityControllerProvider extends $NotifierProvider<IdentityControl
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<void> value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<AsyncValue<void>>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<void>>(value),
+    );
   }
 }
 
-String _$identityControllerHash() => r'8d5b40c89972809f4bb7778c039b065531b3fe3e';
+String _$identityControllerHash() =>
+    r'8d5b40c89972809f4bb7778c039b065531b3fe3e';
 
 /// Attaching and removing ways of signing in. Linking is an authenticated action rather than
 /// something inferred from a shared email, because Spendable stores no email to match on.

--- a/mobile/lib/auth/identity_tokens.g.dart
+++ b/mobile/lib/auth/identity_tokens.g.dart
@@ -12,7 +12,8 @@ part of 'identity_tokens.dart';
 @ProviderFor(identityTokens)
 final identityTokensProvider = IdentityTokensProvider._();
 
-final class IdentityTokensProvider extends $FunctionalProvider<IdentityTokens, IdentityTokens, IdentityTokens>
+final class IdentityTokensProvider
+    extends $FunctionalProvider<IdentityTokens, IdentityTokens, IdentityTokens>
     with $Provider<IdentityTokens> {
   IdentityTokensProvider._()
     : super(
@@ -30,7 +31,8 @@ final class IdentityTokensProvider extends $FunctionalProvider<IdentityTokens, I
 
   @$internal
   @override
-  $ProviderElement<IdentityTokens> $createElement($ProviderPointer pointer) => $ProviderElement(pointer);
+  $ProviderElement<IdentityTokens> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
 
   @override
   IdentityTokens create(Ref ref) {
@@ -39,7 +41,10 @@ final class IdentityTokensProvider extends $FunctionalProvider<IdentityTokens, I
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(IdentityTokens value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<IdentityTokens>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<IdentityTokens>(value),
+    );
   }
 }
 

--- a/mobile/lib/auth/token_storage.g.dart
+++ b/mobile/lib/auth/token_storage.g.dart
@@ -12,7 +12,8 @@ part of 'token_storage.dart';
 @ProviderFor(tokenStorage)
 final tokenStorageProvider = TokenStorageProvider._();
 
-final class TokenStorageProvider extends $FunctionalProvider<TokenStorage, TokenStorage, TokenStorage>
+final class TokenStorageProvider
+    extends $FunctionalProvider<TokenStorage, TokenStorage, TokenStorage>
     with $Provider<TokenStorage> {
   TokenStorageProvider._()
     : super(
@@ -30,7 +31,8 @@ final class TokenStorageProvider extends $FunctionalProvider<TokenStorage, Token
 
   @$internal
   @override
-  $ProviderElement<TokenStorage> $createElement($ProviderPointer pointer) => $ProviderElement(pointer);
+  $ProviderElement<TokenStorage> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
 
   @override
   TokenStorage create(Ref ref) {
@@ -39,7 +41,10 @@ final class TokenStorageProvider extends $FunctionalProvider<TokenStorage, Token
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(TokenStorage value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<TokenStorage>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<TokenStorage>(value),
+    );
   }
 }
 

--- a/mobile/lib/banks/banks_controller.g.dart
+++ b/mobile/lib/banks/banks_controller.g.dart
@@ -14,7 +14,8 @@ part of 'banks_controller.dart';
 final banksControllerProvider = BanksControllerProvider._();
 
 /// Connecting banks and deciding what each account does.
-final class BanksControllerProvider extends $NotifierProvider<BanksController, AsyncValue<void>> {
+final class BanksControllerProvider
+    extends $NotifierProvider<BanksController, AsyncValue<void>> {
   /// Connecting banks and deciding what each account does.
   BanksControllerProvider._()
     : super(
@@ -36,7 +37,10 @@ final class BanksControllerProvider extends $NotifierProvider<BanksController, A
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<void> value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<AsyncValue<void>>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<void>>(value),
+    );
   }
 }
 

--- a/mobile/lib/banks/banks_providers.g.dart
+++ b/mobile/lib/banks/banks_providers.g.dart
@@ -13,7 +13,12 @@ part of 'banks_providers.dart';
 final bankMembersProvider = BankMembersProvider._();
 
 final class BankMembersProvider
-    extends $FunctionalProvider<AsyncValue<List<BankMember>>, List<BankMember>, FutureOr<List<BankMember>>>
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<BankMember>>,
+          List<BankMember>,
+          FutureOr<List<BankMember>>
+        >
     with $FutureModifier<List<BankMember>>, $FutureProvider<List<BankMember>> {
   BankMembersProvider._()
     : super(
@@ -31,8 +36,9 @@ final class BankMembersProvider
 
   @$internal
   @override
-  $FutureProviderElement<List<BankMember>> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(pointer);
+  $FutureProviderElement<List<BankMember>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<BankMember>> create(Ref ref) {
@@ -52,18 +58,25 @@ final bankLogoProvider = BankLogoFamily._();
 /// the same client and held per member instead of by an image cache.
 
 final class BankLogoProvider
-    extends $FunctionalProvider<AsyncValue<Uint8List>, Uint8List, FutureOr<Uint8List>>
+    extends
+        $FunctionalProvider<
+          AsyncValue<Uint8List>,
+          Uint8List,
+          FutureOr<Uint8List>
+        >
     with $FutureModifier<Uint8List>, $FutureProvider<Uint8List> {
   /// Logos come down the authenticated API rather than a public URL, so they are fetched through
   /// the same client and held per member instead of by an image cache.
-  BankLogoProvider._({required BankLogoFamily super.from, required String super.argument})
-    : super(
-        retry: null,
-        name: r'bankLogoProvider',
-        isAutoDispose: false,
-        dependencies: null,
-        $allTransitiveDependencies: null,
-      );
+  BankLogoProvider._({
+    required BankLogoFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'bankLogoProvider',
+         isAutoDispose: false,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
 
   @override
   String debugGetCreateSourceHash() => _$bankLogoHash();
@@ -102,7 +115,8 @@ String _$bankLogoHash() => r'38aa22032bc1b610fa9d253aeab30c015aba8a83';
 /// Logos come down the authenticated API rather than a public URL, so they are fetched through
 /// the same client and held per member instead of by an image cache.
 
-final class BankLogoFamily extends $Family with $FunctionalFamilyOverride<FutureOr<Uint8List>, String> {
+final class BankLogoFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<Uint8List>, String> {
   BankLogoFamily._()
     : super(
         retry: null,
@@ -115,7 +129,8 @@ final class BankLogoFamily extends $Family with $FunctionalFamilyOverride<Future
   /// Logos come down the authenticated API rather than a public URL, so they are fetched through
   /// the same client and held per member instead of by an image cache.
 
-  BankLogoProvider call(String memberId) => BankLogoProvider._(argument: memberId, from: this);
+  BankLogoProvider call(String memberId) =>
+      BankLogoProvider._(argument: memberId, from: this);
 
   @override
   String toString() => r'bankLogoProvider';

--- a/mobile/lib/banks/plaid_link_flow.g.dart
+++ b/mobile/lib/banks/plaid_link_flow.g.dart
@@ -12,7 +12,8 @@ part of 'plaid_link_flow.dart';
 @ProviderFor(plaidLinkFlow)
 final plaidLinkFlowProvider = PlaidLinkFlowProvider._();
 
-final class PlaidLinkFlowProvider extends $FunctionalProvider<PlaidLinkFlow, PlaidLinkFlow, PlaidLinkFlow>
+final class PlaidLinkFlowProvider
+    extends $FunctionalProvider<PlaidLinkFlow, PlaidLinkFlow, PlaidLinkFlow>
     with $Provider<PlaidLinkFlow> {
   PlaidLinkFlowProvider._()
     : super(
@@ -30,7 +31,8 @@ final class PlaidLinkFlowProvider extends $FunctionalProvider<PlaidLinkFlow, Pla
 
   @$internal
   @override
-  $ProviderElement<PlaidLinkFlow> $createElement($ProviderPointer pointer) => $ProviderElement(pointer);
+  $ProviderElement<PlaidLinkFlow> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
 
   @override
   PlaidLinkFlow create(Ref ref) {
@@ -39,7 +41,10 @@ final class PlaidLinkFlowProvider extends $FunctionalProvider<PlaidLinkFlow, Pla
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(PlaidLinkFlow value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<PlaidLinkFlow>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<PlaidLinkFlow>(value),
+    );
   }
 }
 

--- a/mobile/lib/budgets/budgets_controller.g.dart
+++ b/mobile/lib/budgets/budgets_controller.g.dart
@@ -18,7 +18,8 @@ final budgetsControllerProvider = BudgetsControllerProvider._();
 /// Writing budgets. Every write re-reads the summary rather than patching the list: changing one
 /// budget's allocation moves what is left on Spendable, so the row that came back is not the only
 /// one that changed.
-final class BudgetsControllerProvider extends $NotifierProvider<BudgetsController, AsyncValue<void>> {
+final class BudgetsControllerProvider
+    extends $NotifierProvider<BudgetsController, AsyncValue<void>> {
   /// Writing budgets. Every write re-reads the summary rather than patching the list: changing one
   /// budget's allocation moves what is left on Spendable, so the row that came back is not the only
   /// one that changed.
@@ -42,7 +43,10 @@ final class BudgetsControllerProvider extends $NotifierProvider<BudgetsControlle
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<void> value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<AsyncValue<void>>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<void>>(value),
+    );
   }
 }
 

--- a/mobile/lib/budgets/budgets_providers.g.dart
+++ b/mobile/lib/budgets/budgets_providers.g.dart
@@ -14,7 +14,8 @@ part of 'budgets_providers.dart';
 final selectedMonthProvider = SelectedMonthProvider._();
 
 /// Null leaves the choice to the server, which answers for the current month.
-final class SelectedMonthProvider extends $NotifierProvider<SelectedMonth, Date?> {
+final class SelectedMonthProvider
+    extends $NotifierProvider<SelectedMonth, Date?> {
   /// Null leaves the choice to the server, which answers for the current month.
   SelectedMonthProvider._()
     : super(
@@ -36,7 +37,10 @@ final class SelectedMonthProvider extends $NotifierProvider<SelectedMonth, Date?
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Date? value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<Date?>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Date?>(value),
+    );
   }
 }
 
@@ -50,7 +54,14 @@ abstract class _$SelectedMonth extends $Notifier<Date?> {
   @override
   WhenComplete runBuild() {
     final ref = this.ref as $Ref<Date?, Date?>;
-    final element = ref.element as $ClassProviderElement<AnyNotifier<Date?, Date?>, Date?, Object?, Object?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<Date?, Date?>,
+              Date?,
+              Object?,
+              Object?
+            >;
     return element.handleCreate(ref, build);
   }
 }
@@ -58,7 +69,8 @@ abstract class _$SelectedMonth extends $Notifier<Date?> {
 @ProviderFor(BudgetSearch)
 final budgetSearchProvider = BudgetSearchProvider._();
 
-final class BudgetSearchProvider extends $NotifierProvider<BudgetSearch, String?> {
+final class BudgetSearchProvider
+    extends $NotifierProvider<BudgetSearch, String?> {
   BudgetSearchProvider._()
     : super(
         from: null,
@@ -79,7 +91,10 @@ final class BudgetSearchProvider extends $NotifierProvider<BudgetSearch, String?
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(String? value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<String?>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<String?>(value),
+    );
   }
 }
 
@@ -92,7 +107,13 @@ abstract class _$BudgetSearch extends $Notifier<String?> {
   WhenComplete runBuild() {
     final ref = this.ref as $Ref<String?, String?>;
     final element =
-        ref.element as $ClassProviderElement<AnyNotifier<String?, String?>, String?, Object?, Object?>;
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<String?, String?>,
+              String?,
+              Object?,
+              Object?
+            >;
     return element.handleCreate(ref, build);
   }
 }
@@ -101,7 +122,12 @@ abstract class _$BudgetSearch extends $Notifier<String?> {
 final budgetSummaryProvider = BudgetSummaryProvider._();
 
 final class BudgetSummaryProvider
-    extends $FunctionalProvider<AsyncValue<BudgetSummary>, BudgetSummary, FutureOr<BudgetSummary>>
+    extends
+        $FunctionalProvider<
+          AsyncValue<BudgetSummary>,
+          BudgetSummary,
+          FutureOr<BudgetSummary>
+        >
     with $FutureModifier<BudgetSummary>, $FutureProvider<BudgetSummary> {
   BudgetSummaryProvider._()
     : super(
@@ -119,8 +145,9 @@ final class BudgetSummaryProvider
 
   @$internal
   @override
-  $FutureProviderElement<BudgetSummary> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(pointer);
+  $FutureProviderElement<BudgetSummary> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
 
   @override
   FutureOr<BudgetSummary> create(Ref ref) {
@@ -138,7 +165,12 @@ final budgetOptionsProvider = BudgetOptionsProvider._();
 /// The budget picker every other screen offers.
 
 final class BudgetOptionsProvider
-    extends $FunctionalProvider<AsyncValue<List<Budget>>, List<Budget>, FutureOr<List<Budget>>>
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<Budget>>,
+          List<Budget>,
+          FutureOr<List<Budget>>
+        >
     with $FutureModifier<List<Budget>>, $FutureProvider<List<Budget>> {
   /// The budget picker every other screen offers.
   BudgetOptionsProvider._()
@@ -157,8 +189,9 @@ final class BudgetOptionsProvider
 
   @$internal
   @override
-  $FutureProviderElement<List<Budget>> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(pointer);
+  $FutureProviderElement<List<Budget>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Budget>> create(Ref ref) {

--- a/mobile/lib/splits/splits_controller.g.dart
+++ b/mobile/lib/splits/splits_controller.g.dart
@@ -16,7 +16,8 @@ final splitsControllerProvider = SplitsControllerProvider._();
 
 /// Writing splits. Archiving several is N requests rather than a bulk endpoint, because a user
 /// has a handful of splits, not a page of them.
-final class SplitsControllerProvider extends $NotifierProvider<SplitsController, AsyncValue<void>> {
+final class SplitsControllerProvider
+    extends $NotifierProvider<SplitsController, AsyncValue<void>> {
   /// Writing splits. Archiving several is N requests rather than a bulk endpoint, because a user
   /// has a handful of splits, not a page of them.
   SplitsControllerProvider._()
@@ -39,7 +40,10 @@ final class SplitsControllerProvider extends $NotifierProvider<SplitsController,
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<void> value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<AsyncValue<void>>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<void>>(value),
+    );
   }
 }
 

--- a/mobile/lib/splits/splits_providers.g.dart
+++ b/mobile/lib/splits/splits_providers.g.dart
@@ -13,7 +13,12 @@ part of 'splits_providers.dart';
 final splitsProvider = SplitsProvider._();
 
 final class SplitsProvider
-    extends $FunctionalProvider<AsyncValue<List<Split>>, List<Split>, FutureOr<List<Split>>>
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<Split>>,
+          List<Split>,
+          FutureOr<List<Split>>
+        >
     with $FutureModifier<List<Split>>, $FutureProvider<List<Split>> {
   SplitsProvider._()
     : super(
@@ -31,8 +36,9 @@ final class SplitsProvider
 
   @$internal
   @override
-  $FutureProviderElement<List<Split>> $createElement($ProviderPointer pointer) =>
-      $FutureProviderElement(pointer);
+  $FutureProviderElement<List<Split>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Split>> create(Ref ref) {
@@ -45,7 +51,8 @@ String _$splitsHash() => r'88eea8e32b6a3b092b45352388a91742265c0fd6';
 @ProviderFor(SplitSelection)
 final splitSelectionProvider = SplitSelectionProvider._();
 
-final class SplitSelectionProvider extends $NotifierProvider<SplitSelection, Set<String>> {
+final class SplitSelectionProvider
+    extends $NotifierProvider<SplitSelection, Set<String>> {
   SplitSelectionProvider._()
     : super(
         from: null,
@@ -66,7 +73,10 @@ final class SplitSelectionProvider extends $NotifierProvider<SplitSelection, Set
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Set<String> value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<Set<String>>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Set<String>>(value),
+    );
   }
 }
 
@@ -80,7 +90,12 @@ abstract class _$SplitSelection extends $Notifier<Set<String>> {
     final ref = this.ref as $Ref<Set<String>, Set<String>>;
     final element =
         ref.element
-            as $ClassProviderElement<AnyNotifier<Set<String>, Set<String>>, Set<String>, Object?, Object?>;
+            as $ClassProviderElement<
+              AnyNotifier<Set<String>, Set<String>>,
+              Set<String>,
+              Object?,
+              Object?
+            >;
     return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/transactions/transactions_controller.g.dart
+++ b/mobile/lib/transactions/transactions_controller.g.dart
@@ -43,11 +43,15 @@ final class TransactionsControllerProvider
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(AsyncValue<void> value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<AsyncValue<void>>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AsyncValue<void>>(value),
+    );
   }
 }
 
-String _$transactionsControllerHash() => r'684e2fcfec358b2f01f0a8cc8dc555cd96fa1a24';
+String _$transactionsControllerHash() =>
+    r'684e2fcfec358b2f01f0a8cc8dc555cd96fa1a24';
 
 /// Writing transactions. Every write renders the transaction that came back rather than what was
 /// sent: the server re-runs the allocation split on each save, so the response is the only

--- a/mobile/lib/transactions/transactions_providers.g.dart
+++ b/mobile/lib/transactions/transactions_providers.g.dart
@@ -12,7 +12,8 @@ part of 'transactions_providers.dart';
 @ProviderFor(Filters)
 final filtersProvider = FiltersProvider._();
 
-final class FiltersProvider extends $NotifierProvider<Filters, TransactionFilters> {
+final class FiltersProvider
+    extends $NotifierProvider<Filters, TransactionFilters> {
   FiltersProvider._()
     : super(
         from: null,
@@ -33,7 +34,10 @@ final class FiltersProvider extends $NotifierProvider<Filters, TransactionFilter
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(TransactionFilters value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<TransactionFilters>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<TransactionFilters>(value),
+    );
   }
 }
 
@@ -63,7 +67,8 @@ abstract class _$Filters extends $Notifier<TransactionFilters> {
 final transactionsProvider = TransactionsProvider._();
 
 /// Pages append rather than replace. A page shorter than what was asked for is the last one.
-final class TransactionsProvider extends $AsyncNotifierProvider<Transactions, TransactionPage> {
+final class TransactionsProvider
+    extends $AsyncNotifierProvider<Transactions, TransactionPage> {
   /// Pages append rather than replace. A page shorter than what was asked for is the last one.
   TransactionsProvider._()
     : super(
@@ -109,7 +114,8 @@ abstract class _$Transactions extends $AsyncNotifier<TransactionPage> {
 @ProviderFor(Selection)
 final selectionProvider = SelectionProvider._();
 
-final class SelectionProvider extends $NotifierProvider<Selection, Set<String>> {
+final class SelectionProvider
+    extends $NotifierProvider<Selection, Set<String>> {
   SelectionProvider._()
     : super(
         from: null,
@@ -130,7 +136,10 @@ final class SelectionProvider extends $NotifierProvider<Selection, Set<String>> 
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(Set<String> value) {
-    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<Set<String>>(value));
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Set<String>>(value),
+    );
   }
 }
 
@@ -144,7 +153,12 @@ abstract class _$Selection extends $Notifier<Set<String>> {
     final ref = this.ref as $Ref<Set<String>, Set<String>>;
     final element =
         ref.element
-            as $ClassProviderElement<AnyNotifier<Set<String>, Set<String>>, Set<String>, Object?, Object?>;
+            as $ClassProviderElement<
+              AnyNotifier<Set<String>, Set<String>>,
+              Set<String>,
+              Object?,
+              Object?
+            >;
     return element.handleCreate(ref, build);
   }
 }


### PR DESCRIPTION
`dart format --set-exit-if-changed` was policing the `.g.dart` files. build_runner writes them at its own width, so committing them at 110 meant the next regeneration immediately looked unformatted — and the Analyze job failed on a PR that had changed no Dart at all (#774). They are now committed exactly as build_runner emits them, and excluded from the check.

That leaves the thing actually worth catching, which nothing did: a `.g.dart` left behind by a change to the file it is generated from. CI now regenerates and diffs, the same shape as the existing API client drift job.

The diff is mostly one-time churn from re-emitting 15 generated files at their natural width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)