### PR TITLE
Extract the source-agnostic ingest seam

### DIFF
--- a/lib/spendable/banks.ex
+++ b/lib/spendable/banks.ex
@@ -14,6 +14,11 @@ defmodule Spendable.Banks do
   defdelegate get_link_token(scope), to: Actions.GetLinkToken
   defdelegate get_update_link_token(scope, bank_member), to: Actions.GetUpdateLinkToken
   defdelegate update_bank_account(scope, bank_account, attrs), to: Actions.UpdateBankAccount
+  defdelegate upsert_bank_account(scope, bank_member, attrs), to: Actions.UpsertBankAccount
+
+  defdelegate ingest_bank_transactions(scope, bank_account, entries),
+    to: Actions.IngestBankTransactions
+
   defdelegate calculate_credit_card_balance(scope), to: Actions.CalculateCreditCardBalance
   defdelegate queue_sync(bank_member, opts \\ []), to: Actions.QueueSync
   defdelegate queue_historical_sync(scope, bank_member), to: Actions.QueueHistoricalSync

--- a/lib/spendable/banks/actions/ingest_bank_transactions.ex
+++ b/lib/spendable/banks/actions/ingest_bank_transactions.ex
@@ -1,0 +1,82 @@
+defmodule Spendable.Banks.Actions.IngestBankTransactions do
+  @moduledoc false
+
+  import Ecto.Query
+
+  alias Spendable.Banks.Schemas.BankAccount
+  alias Spendable.Banks.Schemas.BankTransaction
+  alias Spendable.Repo
+  alias Spendable.Scope
+  alias Spendable.Transactions
+
+  @doc """
+  Records activity against an account and gives the user a transaction for each entry that is new.
+
+  Entries arrive already normalised, so this is the one path every source shares. Returns how many
+  were new: a source replaying activity we already hold is the normal case, not a failure.
+
+  An entry may name the pending entry it settles, in `replaces`.
+  """
+  def ingest_bank_transactions(
+        %Scope{user: %{id: user_id}} = scope,
+        %BankAccount{user_id: user_id} = bank_account,
+        entries
+      ) do
+    ingested =
+      Enum.count(entries, fn entry ->
+        {replaces, attrs} = Map.pop(entry, :replaces)
+
+        %BankTransaction{user_id: user_id, bank_account_id: bank_account.id}
+        |> BankTransaction.changeset(attrs)
+        |> Repo.insert()
+        |> case do
+          {:ok, bank_transaction} ->
+            create_transaction(bank_transaction, replaces, scope)
+            true
+
+          {:error, _already_ingested} ->
+            false
+        end
+      end)
+
+    {:ok, ingested}
+  end
+
+  def ingest_bank_transactions(_scope, _bank_account, _entries), do: {:error, :not_authorized}
+
+  defp create_transaction(bank_transaction, replaces, scope) do
+    {:ok, transaction} =
+      Transactions.create_transaction(scope, %{
+        "amount" => bank_transaction.amount,
+        "date" => bank_transaction.date,
+        "name" => bank_transaction.name,
+        "reviewed" => false,
+        "bank_transaction_id" => bank_transaction.id
+      })
+
+    replace_pending(transaction, replaces, scope)
+  end
+
+  # A pending transaction is replaced by a settled one under a new id. The user may already have
+  # allocated the pending one, so its allocations move across rather than being asked for twice.
+  defp replace_pending(transaction, replaces, scope) when is_binary(replaces) do
+    query =
+      from(bank_transaction in BankTransaction,
+        where: bank_transaction.user_id == ^scope.user.id,
+        where: bank_transaction.external_id == ^replaces,
+        where: bank_transaction.pending == true,
+        preload: [:transaction]
+      )
+
+    case Repo.one(query) do
+      %BankTransaction{transaction: %{} = pending} = bank_transaction ->
+        {:ok, _moved} = Transactions.replace_pending(scope, pending, transaction)
+        Repo.delete(bank_transaction)
+
+      _nothing_to_replace ->
+        :ok
+    end
+  end
+
+  defp replace_pending(_transaction, _replaces, _scope), do: :ok
+end

--- a/lib/spendable/banks/actions/ingest_bank_transactions_test.exs
+++ b/lib/spendable/banks/actions/ingest_bank_transactions_test.exs
@@ -1,0 +1,97 @@
+defmodule Spendable.Banks.Actions.IngestBankTransactionsTest do
+  use Spendable.DataCase, async: true
+
+  alias Spendable.Accounts
+  alias Spendable.Banks
+  alias Spendable.Scope
+  alias Spendable.TestData
+  alias Spendable.Transactions
+
+  setup do
+    stub(TeslaMock, :call, fn
+      %{method: :post, url: "https://sandbox.plaid.com/item/public_token/exchange"}, _opts ->
+        TeslaHelper.response(body: %{"access_token" => "access-sandbox-token"})
+
+      %{method: :post, url: "https://sandbox.plaid.com/item/get"}, _opts ->
+        TeslaHelper.response(body: TestData.Plaid.item())
+
+      %{method: :post, url: "https://sandbox.plaid.com/institutions/get_by_id"}, _opts ->
+        TeslaHelper.response(body: TestData.Plaid.institution())
+    end)
+
+    {:ok, user} =
+      Accounts.upsert_user_from_oauth(%{
+        external_id: Ecto.UUID.generate(),
+        provider: "google",
+        bank_limit: 1
+      })
+
+    scope = Scope.for_user(user)
+    {:ok, bank_member} = Banks.create_bank_member_from_public_token(scope, "public-sandbox-token")
+
+    {:ok, bank_account} =
+      Banks.upsert_bank_account(scope, bank_member, %{
+        balance: Decimal.new("100.00"),
+        external_id: "acct-1",
+        name: "Checking",
+        sub_type: "checking",
+        type: "depository"
+      })
+
+    entry = %{
+      amount: Decimal.new("-12.50"),
+      date: ~D[2026-08-01],
+      external_id: "txn-1",
+      name: "Coffee",
+      pending: false,
+      replaces: nil
+    }
+
+    %{scope: scope, bank_account: bank_account, entry: entry}
+  end
+
+  test "gives the user a transaction for each new entry", %{
+    scope: scope,
+    bank_account: bank_account,
+    entry: entry
+  } do
+    entries = [entry, %{entry | external_id: "txn-2", name: "Lunch"}]
+
+    assert {:ok, 2} = Banks.ingest_bank_transactions(scope, bank_account, entries)
+    assert [%{name: "Lunch"}, %{name: "Coffee"}] = Transactions.list_transactions(scope)
+  end
+
+  # Every source replays activity we already hold, so a repeat is the normal case rather than a
+  # failure, and it must not hand the user the same charge twice.
+  test "counts a replayed entry as nothing new", %{
+    scope: scope,
+    bank_account: bank_account,
+    entry: entry
+  } do
+    {:ok, 1} = Banks.ingest_bank_transactions(scope, bank_account, [entry])
+
+    assert {:ok, 0} = Banks.ingest_bank_transactions(scope, bank_account, [entry])
+    assert [%{name: "Coffee"}] = Transactions.list_transactions(scope)
+  end
+
+  test "a settled entry replaces the pending entry it names", %{
+    scope: scope,
+    bank_account: bank_account,
+    entry: entry
+  } do
+    {:ok, 1} = Banks.ingest_bank_transactions(scope, bank_account, [%{entry | pending: true}])
+
+    settled = %{entry | external_id: "txn-2", name: "Coffee Roasters", replaces: "txn-1"}
+
+    assert {:ok, 1} = Banks.ingest_bank_transactions(scope, bank_account, [settled])
+    assert [%{name: "Coffee Roasters"}] = Transactions.list_transactions(scope)
+  end
+
+  test "refuses an account belonging to another user", %{bank_account: bank_account, entry: entry} do
+    {:ok, other_user} =
+      Accounts.upsert_user_from_oauth(%{external_id: Ecto.UUID.generate(), provider: "google"})
+
+    assert {:error, :not_authorized} =
+             Banks.ingest_bank_transactions(Scope.for_user(other_user), bank_account, [entry])
+  end
+end

--- a/lib/spendable/banks/actions/sync_member.ex
+++ b/lib/spendable/banks/actions/sync_member.ex
@@ -1,16 +1,13 @@
 defmodule Spendable.Banks.Actions.SyncMember do
   @moduledoc false
 
-  import Ecto.Query
   import Spendable.Banks.Utils.FormatBankMember
 
+  alias Spendable.Banks
   alias Spendable.Banks.Clients.Plaid
-  alias Spendable.Banks.Schemas.BankAccount
   alias Spendable.Banks.Schemas.BankMember
-  alias Spendable.Banks.Schemas.BankTransaction
   alias Spendable.Repo
   alias Spendable.Scope
-  alias Spendable.Transactions
 
   @page_size 500
   @default_days 30
@@ -67,15 +64,10 @@ defmodule Spendable.Banks.Actions.SyncMember do
   end
 
   defp upsert_account(details, bank_member, scope) do
-    attrs = format_bank_account(details)
+    {:ok, bank_account} =
+      Banks.upsert_bank_account(scope, bank_member, format_bank_account(details))
 
-    account =
-      Repo.get_by(BankAccount, user_id: scope.user.id, external_id: details["account_id"]) ||
-        %BankAccount{user_id: scope.user.id, bank_member_id: bank_member.id}
-
-    {:ok, account} = account |> BankAccount.changeset(attrs) |> Repo.insert_or_update()
-
-    account
+    bank_account
   end
 
   defp sync_transactions(account, scope, bank_member, start_date, offset \\ 0) do
@@ -83,7 +75,8 @@ defmodule Spendable.Banks.Actions.SyncMember do
 
     case Plaid.account_transactions(bank_member.plaid_token, account.external_id, start_date, opts) do
       {:ok, %{body: %{"transactions" => transactions} = response}} ->
-        Enum.each(transactions, &sync_transaction(&1, account, scope))
+        entries = Enum.map(transactions, &format_bank_transaction/1)
+        {:ok, _ingested} = Banks.ingest_bank_transactions(scope, account, entries)
 
         with %{"total_transactions" => total} when total > offset + @page_size <- response do
           sync_transactions(account, scope, bank_member, start_date, offset + @page_size)
@@ -93,56 +86,6 @@ defmodule Spendable.Banks.Actions.SyncMember do
         :ok
     end
   end
-
-  # Plaid replays transactions we already hold, so a duplicate external id is the normal case and
-  # not an error worth failing the sync over.
-  defp sync_transaction(details, account, scope) do
-    attrs = format_bank_transaction(details)
-
-    %BankTransaction{user_id: scope.user.id, bank_account_id: account.id}
-    |> BankTransaction.changeset(attrs)
-    |> Repo.insert()
-    |> case do
-      {:ok, bank_transaction} -> create_transaction(bank_transaction, details, scope)
-      {:error, _already_synced} -> :ok
-    end
-  end
-
-  defp create_transaction(bank_transaction, details, scope) do
-    {:ok, transaction} =
-      Transactions.create_transaction(scope, %{
-        "amount" => bank_transaction.amount,
-        "date" => bank_transaction.date,
-        "name" => bank_transaction.name,
-        "reviewed" => false,
-        "bank_transaction_id" => bank_transaction.id
-      })
-
-    replace_pending(transaction, details, scope)
-  end
-
-  # A pending transaction is replaced by a settled one under a new id. The user may already have
-  # allocated the pending one, so its allocations move across rather than being asked for twice.
-  defp replace_pending(transaction, %{"pending_transaction_id" => pending_id}, scope)
-       when is_binary(pending_id) do
-    query =
-      from(bank_transaction in BankTransaction,
-        where: bank_transaction.external_id == ^pending_id,
-        where: bank_transaction.pending == true,
-        preload: [:transaction]
-      )
-
-    case Repo.one(query) do
-      %BankTransaction{transaction: %{} = pending} = bank_transaction ->
-        {:ok, _moved} = Transactions.replace_pending(scope, pending, transaction)
-        Repo.delete(bank_transaction)
-
-      _nothing_to_replace ->
-        :ok
-    end
-  end
-
-  defp replace_pending(_transaction, _details, _scope), do: :ok
 
   defp format_bank_account(details) do
     available = Decimal.new("#{details["balances"]["available"] || 0}")
@@ -172,7 +115,8 @@ defmodule Spendable.Banks.Actions.SyncMember do
       date: details["date"],
       external_id: details["transaction_id"],
       name: details["name"],
-      pending: details["pending"]
+      pending: details["pending"],
+      replaces: details["pending_transaction_id"]
     }
   end
 end

--- a/lib/spendable/banks/actions/upsert_bank_account.ex
+++ b/lib/spendable/banks/actions/upsert_bank_account.ex
@@ -1,0 +1,30 @@
+defmodule Spendable.Banks.Actions.UpsertBankAccount do
+  @moduledoc false
+
+  alias Spendable.Banks.Schemas.BankAccount
+  alias Spendable.Banks.Schemas.BankMember
+  alias Spendable.Repo
+  alias Spendable.Scope
+
+  @doc """
+  Records one of a connection's accounts as the source last reported it.
+
+  Matched on `external_id`, which is what makes a second sync update the account already held
+  rather than adding a copy of it.
+  """
+  def upsert_bank_account(
+        %Scope{user: %{id: user_id}},
+        %BankMember{user_id: user_id} = bank_member,
+        %{external_id: external_id} = attrs
+      ) do
+    bank_account =
+      Repo.get_by(BankAccount, user_id: user_id, external_id: external_id) ||
+        %BankAccount{user_id: user_id, bank_member_id: bank_member.id}
+
+    bank_account
+    |> BankAccount.changeset(attrs)
+    |> Repo.insert_or_update()
+  end
+
+  def upsert_bank_account(_scope, _bank_member, _attrs), do: {:error, :not_authorized}
+end

--- a/lib/spendable/banks/actions/upsert_bank_account_test.exs
+++ b/lib/spendable/banks/actions/upsert_bank_account_test.exs
@@ -1,0 +1,75 @@
+defmodule Spendable.Banks.Actions.UpsertBankAccountTest do
+  use Spendable.DataCase, async: true
+
+  alias Spendable.Accounts
+  alias Spendable.Banks
+  alias Spendable.Banks.Schemas.BankAccount
+  alias Spendable.Scope
+  alias Spendable.TestData
+
+  setup do
+    stub(TeslaMock, :call, fn
+      %{method: :post, url: "https://sandbox.plaid.com/item/public_token/exchange"}, _opts ->
+        TeslaHelper.response(body: %{"access_token" => "access-sandbox-token"})
+
+      %{method: :post, url: "https://sandbox.plaid.com/item/get"}, _opts ->
+        TeslaHelper.response(body: TestData.Plaid.item())
+
+      %{method: :post, url: "https://sandbox.plaid.com/institutions/get_by_id"}, _opts ->
+        TeslaHelper.response(body: TestData.Plaid.institution())
+    end)
+
+    {:ok, user} =
+      Accounts.upsert_user_from_oauth(%{
+        external_id: Ecto.UUID.generate(),
+        provider: "google",
+        bank_limit: 1
+      })
+
+    scope = Scope.for_user(user)
+    {:ok, bank_member} = Banks.create_bank_member_from_public_token(scope, "public-sandbox-token")
+
+    attrs = %{
+      balance: Decimal.new("100.00"),
+      external_id: "acct-1",
+      name: "Checking",
+      number: "4321",
+      sub_type: "checking",
+      type: "depository"
+    }
+
+    %{scope: scope, bank_member: bank_member, attrs: attrs}
+  end
+
+  test "records an account the connection has not reported before", %{
+    scope: scope,
+    bank_member: bank_member,
+    attrs: attrs
+  } do
+    assert {:ok, %BankAccount{id: "bka_" <> _uxid, name: "Checking", sync: true}} =
+             Banks.upsert_bank_account(scope, bank_member, attrs)
+  end
+
+  # A second sync reports the same accounts, and the balance is the part that moved.
+  test "updates the account already held rather than adding a copy", %{
+    scope: scope,
+    bank_member: bank_member,
+    attrs: attrs
+  } do
+    {:ok, %{id: id}} = Banks.upsert_bank_account(scope, bank_member, attrs)
+
+    assert {:ok, %BankAccount{id: ^id, balance: balance}} =
+             Banks.upsert_bank_account(scope, bank_member, %{attrs | balance: Decimal.new("55.00")})
+
+    assert Decimal.eq?(balance, "55.00")
+    assert [%{bank_accounts: [_one]}] = Banks.list_bank_members(scope)
+  end
+
+  test "refuses a connection belonging to another user", %{bank_member: bank_member, attrs: attrs} do
+    {:ok, other_user} =
+      Accounts.upsert_user_from_oauth(%{external_id: Ecto.UUID.generate(), provider: "google"})
+
+    assert {:error, :not_authorized} =
+             Banks.upsert_bank_account(Scope.for_user(other_user), bank_member, attrs)
+  end
+end


### PR DESCRIPTION
First slice of Phase 3. FinanceKit delivers accounts and activity from the device, so the parts of `SyncMember` that are not about Plaid move out to actions the context exposes:

- `Banks.upsert_bank_account/3` - matched on `external_id`, which is what makes a re-sync update rather than duplicate.
- `Banks.ingest_bank_transactions/3` - takes normalised entries, dedupes on the existing `(external_id, bank_account_id)` index, creates the user-facing transaction, and moves a pending charge's allocations across. Returns how many entries were new.

`SyncMember` keeps the Plaid payload shaping and normalises `pending_transaction_id` into a `replaces` key, the one thing ingest needs to know about settling.

Behaviour-preserving: `sync_member_test.exs` passes unedited. The ingest query also filters on `user_id`, which it did not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)