### PR TITLE
Let a bank member come from somewhere other than Plaid

### DIFF
--- a/lib/spendable/banks/actions/create_bank_member_from_public_token_test.exs
+++ b/lib/spendable/banks/actions/create_bank_member_from_public_token_test.exs
@@ -65,6 +65,25 @@ defmodule Spendable.Banks.Actions.CreateBankMemberFromPublicTokenTest do
     assert %{external_id: ["has already been taken"]} = errors_on(changeset)
   end
 
+  # An external id is only unique within the provider that issued it, so it cannot be unique
+  # across users - FinanceKit names its connection the same thing on every device.
+  test "two users may hold a connection under the same external id", %{scope: scope} do
+    {:ok, _mine} = Banks.create_bank_member_from_public_token(scope, "public-sandbox-token")
+
+    {:ok, other_user} =
+      Accounts.upsert_user_from_oauth(%{
+        external_id: Ecto.UUID.generate(),
+        provider: "google",
+        bank_limit: 1
+      })
+
+    assert {:ok, %BankMember{}} =
+             Banks.create_bank_member_from_public_token(
+               Scope.for_user(other_user),
+               "public-sandbox-token"
+             )
+  end
+
   test "refuses once the user is at their bank limit", %{scope: scope} do
     {:ok, _first} = Banks.create_bank_member_from_public_token(scope, "public-sandbox-token")
 

--- a/lib/spendable/banks/schemas/bank_member.ex
+++ b/lib/spendable/banks/schemas/bank_member.ex
@@ -14,6 +14,7 @@ defmodule Spendable.Banks.Schemas.BankMember do
     field :provider, :string
     field :status, :string
     field :plaid_token, :string, redact: true
+    field :history_token, :string
 
     belongs_to :user, User
     has_many :bank_accounts, BankAccount, preload_order: [asc: :name]
@@ -23,8 +24,8 @@ defmodule Spendable.Banks.Schemas.BankMember do
 
   def changeset(member \\ %__MODULE__{}, attrs) do
     member
-    |> cast(attrs, [:external_id, :institution_id, :logo, :name, :provider, :status])
+    |> cast(attrs, [:external_id, :history_token, :institution_id, :logo, :name, :provider, :status])
     |> validate_required([:external_id, :name, :provider])
-    |> unique_constraint(:external_id)
+    |> unique_constraint(:external_id, name: :bank_members_user_id_external_id_index)
   end
 end

--- a/priv/repo/migrations/20260816161425_support_non_plaid_bank_members.exs
+++ b/priv/repo/migrations/20260816161425_support_non_plaid_bank_members.exs
@@ -1,0 +1,18 @@
+defmodule Spendable.Repo.Migrations.SupportNonPlaidBankMembers do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    alter table(:bank_members) do
+      modify :plaid_token, :text, null: true, from: {:text, null: false}
+      add :history_token, :text
+    end
+
+    # External ids are only unique within the provider that issued them, so the index that made
+    # them unique across every user has to go. Added first, so uniqueness is never unenforced.
+    create unique_index(:bank_members, [:user_id, :external_id], concurrently: true)
+    drop unique_index(:bank_members, [:external_id], concurrently: true)
+  end
+end


### PR DESCRIPTION
Stacked on #777.

- `plaid_token` nullable - FinanceKit holds no access token.
- `unique_index(:bank_members, [:external_id])` becomes `[:user_id, :external_id]`. The old one is global, and FinanceKit names its connection the same thing on every device, so exactly one user in the system could have held it. Created concurrently, and the new index goes in before the old one comes out so uniqueness is never unenforced.
- `history_token` added, where the FinanceKit cursor will live.

The changeset keeps the "has already been taken" error on `external_id` rather than letting it default to `user_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)