### PR TITLE
Give the device a connection to report into

### DIFF
--- a/lib/spendable/banks.ex
+++ b/lib/spendable/banks.ex
@@ -11,6 +11,7 @@ defmodule Spendable.Banks do
   defdelegate create_bank_member_from_public_token(scope, public_token),
     to: Actions.CreateBankMemberFromPublicToken
 
+  defdelegate upsert_finance_kit_member(scope), to: Actions.UpsertFinanceKitMember
   defdelegate get_link_token(scope), to: Actions.GetLinkToken
   defdelegate get_update_link_token(scope, bank_member), to: Actions.GetUpdateLinkToken
   defdelegate update_bank_account(scope, bank_account, attrs), to: Actions.UpdateBankAccount

--- a/lib/spendable/banks/actions/upsert_finance_kit_member.ex
+++ b/lib/spendable/banks/actions/upsert_finance_kit_member.ex
@@ -1,0 +1,35 @@
+defmodule Spendable.Banks.Actions.UpsertFinanceKitMember do
+  @moduledoc false
+
+  alias Spendable.Banks.Schemas.BankMember
+  alias Spendable.Repo
+  alias Spendable.Scope
+
+  @external_id "finance_kit"
+
+  @doc """
+  The one connection holding whatever the device reads out of Wallet - Apple Card, Apple Cash and
+  Apple Savings alike.
+
+  Idempotent, because the app asks for it every time the user authorizes it, and the answer
+  carries the `history_token` saying where the last read left off.
+  """
+  def upsert_finance_kit_member(%Scope{user: user}) do
+    case Repo.get_by(BankMember, user_id: user.id, external_id: @external_id) do
+      %BankMember{} = bank_member ->
+        {:ok, Repo.preload(bank_member, :bank_accounts)}
+
+      nil ->
+        # No accounts until the device sends them, but an empty list is readable where an
+        # unloaded one is not.
+        %BankMember{user_id: user.id, bank_accounts: []}
+        |> BankMember.changeset(%{
+          external_id: @external_id,
+          name: "Apple",
+          provider: "FinanceKit",
+          status: "CONNECTED"
+        })
+        |> Repo.insert()
+    end
+  end
+end

--- a/lib/spendable/banks/actions/upsert_finance_kit_member_test.exs
+++ b/lib/spendable/banks/actions/upsert_finance_kit_member_test.exs
@@ -1,0 +1,44 @@
+defmodule Spendable.Banks.Actions.UpsertFinanceKitMemberTest do
+  use Spendable.DataCase, async: true
+
+  alias Spendable.Accounts
+  alias Spendable.Banks
+  alias Spendable.Banks.Schemas.BankMember
+  alias Spendable.Scope
+
+  setup do
+    {:ok, user} =
+      Accounts.upsert_user_from_oauth(%{external_id: Ecto.UUID.generate(), provider: "google"})
+
+    %{scope: Scope.for_user(user)}
+  end
+
+  test "creates the connection the device reports into", %{scope: scope} do
+    assert {:ok, %BankMember{name: "Apple", provider: "FinanceKit", plaid_token: nil}} =
+             Banks.upsert_finance_kit_member(scope)
+  end
+
+  # The app asks on every authorization, and a second connection would split the accounts in two.
+  test "asking twice returns the connection already held", %{scope: scope} do
+    {:ok, %{id: id}} = Banks.upsert_finance_kit_member(scope)
+
+    assert {:ok, %BankMember{id: ^id}} = Banks.upsert_finance_kit_member(scope)
+    assert [%{name: "Apple"}] = Banks.list_bank_members(scope)
+  end
+
+  test "comes back with its accounts loaded", %{scope: scope} do
+    {:ok, member} = Banks.upsert_finance_kit_member(scope)
+
+    {:ok, _account} =
+      Banks.upsert_bank_account(scope, member, %{
+        balance: Decimal.new("-42.00"),
+        external_id: "apple-card",
+        name: "Apple Card",
+        sub_type: "credit card",
+        type: "credit"
+      })
+
+    assert {:ok, %BankMember{bank_accounts: [%{name: "Apple Card"}]}} =
+             Banks.upsert_finance_kit_member(scope)
+  end
+end


### PR DESCRIPTION
Stacked on #778.

`Banks.upsert_finance_kit_member/1` - one connection per user, holding Apple Card, Apple Cash and Apple Savings together, the same way a Plaid connection holds a bank's accounts. It comes back with its accounts loaded and, later, the `history_token` saying where the device's last read left off.

Named `upsert_*` rather than the plan's `create_finance_kit_member`: the app asks for it on every authorization, and a second connection would split the accounts in two.

Not done here, contrary to the plan: this does not clean up the `Repo.insert(%BankMember{})` calls in `bank_logo_controller_test.exs` and `plaid_controller_test.exs`. Those need a member with a `logo` or a `plaid_token`, which a FinanceKit member has neither of, so routing them through this action would make the setup worse rather than better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)