### PR TITLE
Restate and remove charges the bank revises

### DIFF
--- a/lib/spendable/banks.ex
+++ b/lib/spendable/banks.ex
@@ -20,6 +20,10 @@ defmodule Spendable.Banks do
   defdelegate ingest_bank_transactions(scope, bank_account, entries),
     to: Actions.IngestBankTransactions
 
+  defdelegate get_bank_transaction(scope, by), to: Actions.GetBankTransaction
+  defdelegate update_bank_transaction(scope, bank_transaction, attrs), to: Actions.UpdateBankTransaction
+  defdelegate delete_bank_transaction(scope, bank_transaction), to: Actions.DeleteBankTransaction
+
   defdelegate calculate_credit_card_balance(scope), to: Actions.CalculateCreditCardBalance
   defdelegate queue_sync(bank_member, opts \\ []), to: Actions.QueueSync
   defdelegate queue_historical_sync(scope, bank_member), to: Actions.QueueHistoricalSync

--- a/lib/spendable/banks/CONTEXT.md
+++ b/lib/spendable/banks/CONTEXT.md
@@ -1,12 +1,16 @@
 # Banks
 
-Connections to financial institutions through Plaid, and the activity synced from them.
+Connections to financial institutions, and the activity that comes from them.
 
 ## Language
 
 **Bank Member**:
 One connection to one institution, holding the token that keeps it alive.
 _Avoid_: Connection, institution, item, link
+
+**Provider**:
+Who a **Bank Member**'s activity comes from - Plaid, or FinanceKit.
+_Avoid_: Source, integration
 
 **Bank Account**:
 A single account held at a **Bank Member** - a checking account, a credit card.
@@ -25,8 +29,12 @@ Whether a **Bank Account**'s activity is pulled at all. A user may connect an ac
 _Avoid_: Enabled, active
 
 **Pending**:
-A **Bank Transaction** the bank has not settled, which will be replaced by a settled one under a different id.
+A **Bank Transaction** the bank has not settled, and will later settle.
 _Avoid_: Unconfirmed, provisional
+
+**History Token**:
+An opaque marker of where the device's last read of Wallet left off.
+_Avoid_: Cursor, checkpoint
 
 **Link Token**:
 A short-lived token that lets Plaid Link open, either for a new **Bank Member** or to repair an existing one.
@@ -42,7 +50,7 @@ _Avoid_: State, health
 - A **Bank Account** has many **Bank Transactions**
 - A **Bank Transaction** produces one **Transaction**, which is the one the user works with
 - A **Bank Account** may be assigned to a **Budget**, and then supplies that budget's balance
-- A **User**'s **Bank Limit** caps how many **Bank Members** they may hold
+- A **User**'s **Bank Limit** caps how many Plaid **Bank Members** they may hold
 
 ## Example dialogue
 
@@ -56,3 +64,4 @@ _Avoid_: State, health
 
 - "balance" on a **Bank Account** is what the bank reports, not a **Budget**'s derived balance - resolved: they are separate concepts owned by separate contexts.
 - Plaid calls a connection an "item" - resolved: we call it a **Bank Member**, and "item" appears only at the client boundary.
+- FinanceKit names account kinds its own way - resolved: a **Bank Account**'s `type` and `sub_type` keep the Plaid vocabulary whatever the **Provider**, so there is one name for each kind of account.

--- a/lib/spendable/banks/actions/delete_bank_transaction.ex
+++ b/lib/spendable/banks/actions/delete_bank_transaction.ex
@@ -1,0 +1,30 @@
+defmodule Spendable.Banks.Actions.DeleteBankTransaction do
+  @moduledoc false
+
+  alias Spendable.Banks.Schemas.BankTransaction
+  alias Spendable.Repo
+  alias Spendable.Scope
+  alias Spendable.Transactions
+
+  @doc """
+  Removes a charge the bank has taken back - a reversed or declined authorization.
+
+  The user's review and allocations go with it. That is right where updating in place is right
+  for a charge that settled: this one did not happen at all. Plaid has no equivalent.
+  """
+  def delete_bank_transaction(
+        %Scope{user: %{id: user_id}} = scope,
+        %BankTransaction{user_id: user_id} = bank_transaction
+      ) do
+    Repo.transaction(fn ->
+      %{transaction: transaction} = Repo.preload(bank_transaction, :transaction)
+
+      {:ok, _gone} = Transactions.delete_transaction(scope, transaction)
+      {:ok, deleted} = Repo.delete(bank_transaction)
+
+      deleted
+    end)
+  end
+
+  def delete_bank_transaction(_scope, _bank_transaction), do: {:error, :not_authorized}
+end

--- a/lib/spendable/banks/actions/delete_bank_transaction_test.exs
+++ b/lib/spendable/banks/actions/delete_bank_transaction_test.exs
@@ -1,0 +1,37 @@
+defmodule Spendable.Banks.Actions.DeleteBankTransactionTest do
+  use Spendable.DataCase, async: true
+
+  alias Spendable.Accounts
+  alias Spendable.Banks
+  alias Spendable.Scope
+  alias Spendable.TestData
+  alias Spendable.Transactions
+
+  setup do
+    {:ok, user} =
+      Accounts.upsert_user_from_oauth(%{external_id: Ecto.UUID.generate(), provider: "google"})
+
+    scope = Scope.for_user(user)
+    {_account, bank_transaction} = TestData.FinanceKit.card_with_charge(scope)
+
+    %{scope: scope, bank_transaction: bank_transaction}
+  end
+
+  # A declined or reversed authorization did not happen, so the user's work on it goes too.
+  test "takes the transaction with it", %{scope: scope, bank_transaction: bank_transaction} do
+    assert {:ok, _deleted} = Banks.delete_bank_transaction(scope, bank_transaction)
+
+    assert [] = Transactions.list_transactions(scope)
+
+    assert {:error, :bank_transaction_not_found} =
+             Banks.get_bank_transaction(scope, external_id: "txn-1")
+  end
+
+  test "refuses a charge belonging to another user", %{bank_transaction: bank_transaction} do
+    {:ok, other_user} =
+      Accounts.upsert_user_from_oauth(%{external_id: Ecto.UUID.generate(), provider: "google"})
+
+    assert {:error, :not_authorized} =
+             Banks.delete_bank_transaction(Scope.for_user(other_user), bank_transaction)
+  end
+end

--- a/lib/spendable/banks/actions/get_bank_transaction.ex
+++ b/lib/spendable/banks/actions/get_bank_transaction.ex
@@ -1,0 +1,14 @@
+defmodule Spendable.Banks.Actions.GetBankTransaction do
+  @moduledoc false
+
+  alias Spendable.Banks.Schemas.BankTransaction
+  alias Spendable.Repo
+  alias Spendable.Scope
+
+  def get_bank_transaction(%Scope{user: %{id: user_id}}, by) do
+    case Repo.get_by(BankTransaction, Keyword.put(by, :user_id, user_id)) do
+      %BankTransaction{} = bank_transaction -> {:ok, bank_transaction}
+      nil -> {:error, :bank_transaction_not_found}
+    end
+  end
+end

--- a/lib/spendable/banks/actions/update_bank_transaction.ex
+++ b/lib/spendable/banks/actions/update_bank_transaction.ex
@@ -1,0 +1,37 @@
+defmodule Spendable.Banks.Actions.UpdateBankTransaction do
+  @moduledoc false
+
+  alias Spendable.Banks.Schemas.BankTransaction
+  alias Spendable.Repo
+  alias Spendable.Scope
+  alias Spendable.Transactions
+
+  @doc """
+  Restates a charge the bank has revised - the usual one being an authorization that settled for
+  a different amount under the same id.
+
+  Plaid issues a new id instead, which is what `Transactions.replace_pending/3` is for. Updating
+  in place means the user's own allocations survive and only the Spendable remainder moves.
+  """
+  def update_bank_transaction(
+        %Scope{user: %{id: user_id}} = scope,
+        %BankTransaction{user_id: user_id} = bank_transaction,
+        attrs
+      ) do
+    Repo.transaction(fn ->
+      {:ok, updated} = bank_transaction |> BankTransaction.changeset(attrs) |> Repo.update()
+      %{transaction: transaction} = Repo.preload(updated, :transaction)
+
+      {:ok, _restated} =
+        Transactions.update_transaction(scope, transaction, %{
+          "amount" => updated.amount,
+          "date" => updated.date,
+          "name" => updated.name
+        })
+
+      updated
+    end)
+  end
+
+  def update_bank_transaction(_scope, _bank_transaction, _attrs), do: {:error, :not_authorized}
+end

--- a/lib/spendable/banks/actions/update_bank_transaction_test.exs
+++ b/lib/spendable/banks/actions/update_bank_transaction_test.exs
@@ -1,0 +1,71 @@
+defmodule Spendable.Banks.Actions.UpdateBankTransactionTest do
+  use Spendable.DataCase, async: true
+
+  alias Spendable.Accounts
+  alias Spendable.Banks
+  alias Spendable.Banks.Schemas.BankTransaction
+  alias Spendable.Budgets
+  alias Spendable.Scope
+  alias Spendable.TestData
+  alias Spendable.Transactions
+
+  setup do
+    {:ok, user} =
+      Accounts.upsert_user_from_oauth(%{external_id: Ecto.UUID.generate(), provider: "google"})
+
+    scope = Scope.for_user(user)
+    {_account, bank_transaction} = TestData.FinanceKit.card_with_charge(scope)
+
+    %{scope: scope, bank_transaction: bank_transaction}
+  end
+
+  test "restates the charge and the transaction it produced", %{
+    scope: scope,
+    bank_transaction: bank_transaction
+  } do
+    attrs = %{amount: Decimal.new("-22.50"), date: ~D[2026-08-02], name: "Coffee Roasters", pending: false}
+
+    assert {:ok, %BankTransaction{pending: false}} =
+             Banks.update_bank_transaction(scope, bank_transaction, attrs)
+
+    assert [%{name: "Coffee Roasters", date: ~D[2026-08-02], amount: amount}] =
+             Transactions.list_transactions(scope)
+
+    assert Decimal.eq?(amount, "-22.50")
+  end
+
+  # The whole reason to update in place: the user already decided where this money came from, and
+  # a charge settling for a different amount must not ask them again.
+  test "keeps what the user allocated and moves only the remainder", %{
+    scope: scope,
+    bank_transaction: bank_transaction
+  } do
+    {:ok, budget} = Budgets.create_budget(scope, %{"name" => "Coffee"})
+    [transaction] = Transactions.list_transactions(scope)
+
+    {:ok, _allocated} =
+      Transactions.update_transaction(scope, transaction, %{
+        "budget_allocations" => %{"0" => %{"amount" => "-5.00", "budget_id" => budget.id}}
+      })
+
+    attrs = %{amount: Decimal.new("-22.50"), date: ~D[2026-08-01], name: "Coffee", pending: false}
+    {:ok, _updated} = Banks.update_bank_transaction(scope, bank_transaction, attrs)
+
+    {:ok, spendable} = Budgets.find_or_create_spendable_budget(scope)
+    [restated] = Transactions.list_transactions(scope)
+    by_budget = Map.new(restated.budget_allocations, &{&1.budget_id, &1.amount})
+
+    assert Decimal.eq?(by_budget[budget.id], "-5.00")
+    assert Decimal.eq?(by_budget[spendable.id], "-17.50")
+  end
+
+  test "refuses a charge belonging to another user", %{bank_transaction: bank_transaction} do
+    {:ok, other_user} =
+      Accounts.upsert_user_from_oauth(%{external_id: Ecto.UUID.generate(), provider: "google"})
+
+    attrs = %{amount: Decimal.new("-1.00"), date: ~D[2026-08-01], name: "Theirs", pending: false}
+
+    assert {:error, :not_authorized} =
+             Banks.update_bank_transaction(Scope.for_user(other_user), bank_transaction, attrs)
+  end
+end

--- a/test/support/test_data/finance_kit.ex
+++ b/test/support/test_data/finance_kit.ex
@@ -1,0 +1,44 @@
+defmodule Spendable.TestData.FinanceKit do
+  @moduledoc false
+
+  alias Spendable.Banks
+
+  @doc """
+  One charge on an Apple Card, built the way the device would send it.
+
+  Every record still goes through the context; this only saves repeating the three calls it takes
+  to get from a user to a charge.
+  """
+  def card_with_charge(scope, entry \\ %{}) do
+    {:ok, member} = Banks.upsert_finance_kit_member(scope)
+
+    {:ok, bank_account} =
+      Banks.upsert_bank_account(scope, member, %{
+        balance: Decimal.new("-42.00"),
+        external_id: "apple-card",
+        name: "Apple Card",
+        sub_type: "credit card",
+        type: "credit"
+      })
+
+    entry = charge(entry)
+    {:ok, 1} = Banks.ingest_bank_transactions(scope, bank_account, [entry])
+    {:ok, bank_transaction} = Banks.get_bank_transaction(scope, external_id: entry.external_id)
+
+    {bank_account, bank_transaction}
+  end
+
+  def charge(attrs \\ %{}) do
+    Map.merge(
+      %{
+        amount: Decimal.new("-20.00"),
+        date: ~D[2026-08-01],
+        external_id: "txn-1",
+        name: "Coffee",
+        pending: true,
+        replaces: nil
+      },
+      attrs
+    )
+  end
+end


### PR DESCRIPTION
Stacked on #780.

FinanceKit reports `inserted`, `updated` and `deleted`. The first is already handled by `Banks.ingest_bank_transactions/3`; this adds the other two, plus the getter the ingest endpoint needs to resolve an external id.

- `Banks.update_bank_transaction/3` - a FinanceKit charge **keeps its id** when it settles, where Plaid issues a new one (which is what `Transactions.replace_pending/3` exists for). So this updates in place. `Transaction.changeset` re-runs `allocate_spendable/1`, so a manual allocation survives and only the Spendable remainder moves - asserted directly.
- `Banks.delete_bank_transaction/2` - a reversed or declined authorization. The transaction and its allocations go too. That discards the user's work on that row, which is right, because the charge did not happen.
- `Banks.get_bank_transaction/2` - same shape as `get_bank_member/2`.

`Spendable.TestData.FinanceKit` holds the shared setup; every record in it is still created through a context function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)